### PR TITLE
Python: Late binding on OS X

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -130,7 +130,13 @@ else()
 	endif()
 endif()
 
-target_link_libraries(binding_python_lib ${LIBSEDML_LIBRARY}-static ${PYTHON_LIBRARIES})
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
+	#Use late binding on OS X
+	set_target_properties(binding_python_lib PROPERTIES LINK_FLAGS "-undefined dynamic_lookup")
+	target_link_libraries(binding_python_lib ${LIBSEDML_LIBRARY}-static)
+else()
+	target_link_libraries(binding_python_lib ${LIBSEDML_LIBRARY}-static ${PYTHON_LIBRARIES})
+endif()
 
 # 
 # Determine the python installation directory


### PR DESCRIPTION
Hi Frank, this change enables late binding for the Python interface on Mac OS X. Without late bindings, the binary can only be used with the exact same Python interpreter. In the [Tellurium](http://tellurium.analogmachine.org/) project, which we develop in the Sauro lab, we need to ship all libraries this way, since Tellurium's interpreter is different than the system or homebrew Python.

I'm not aware of any downside, so it's always enabled for Mac in this changeset.