### PR TITLE
add libNuML include dir to swig command

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -81,6 +81,7 @@ ADD_CUSTOM_COMMAND(
       -I${CMAKE_CURRENT_SOURCE_DIR}/../../sedml
       -I${CMAKE_CURRENT_SOURCE_DIR}
       -I${LIBSBML_INCLUDE_DIR}/
+      -I${LIBNUML_INCLUDE_DIR}/
       -c++
       -python    
       ${SWIG_EXTRA_FLAGS}     


### PR DESCRIPTION
It looks like libsedml.i %includes numl headers, e.g. in bindings/swig/libsedml.i:
```
%include <numl/NUMLNamespaces.h>
%include numl/NUMLReader.h
%include numl/NUMLWriter.h
%include numl/NUMLTypeCodes.h
...
```

When I tried to build libsedml on OS X, it failed to find these headers. This patch just adds `-I${LIBNUML_INCLUDE_DIR}/` to the flags for the swig command.