### PR TITLE
Proposed changes to make use of CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -551,11 +551,11 @@ if(UNIX)
         set(BUILD_DEFINITIONS "${BUILD_DEFINITIONS} -DLINUX")
     endif(APPLE)
 
-    add_definitions( -DPACKAGE_VERSION=\"${PACKAGE_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\")
-    set(BUILD_DEFINITIONS "${BUILD_DEFINITIONS} -DPACKAGE_VERSION=\"${PACKAGE_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\"")
+    add_definitions( -DPACKAGE_VERSION=\"${PROJECT_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\")
+    set(BUILD_DEFINITIONS "${BUILD_DEFINITIONS} -DPACKAGE_VERSION=\"${PROJECT_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\"")
 
 else(UNIX)
-    add_definitions(-DPACKAGE_VERSION=\"${PACKAGE_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\")
+    add_definitions(-DPACKAGE_VERSION=\"${PROJECT_VERSION}\"  -DPACKAGE_NAME=\"${PROJECT_NAME}\")
     
     add_definitions(-DWIN32)
     set(BUILD_DEFINITIONS "${BUILD_DEFINITIONS} -DWIN32")
@@ -792,7 +792,7 @@ endif()
 
 message(STATUS "
 ----------------------------------------------------------------------
-libSEDML version ${PACKAGE_VERSION}
+libSEDML version ${PROJECT_VERSION}
 ----------------------------------------------------------------------
 
    More information and the latest version are available online at

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,11 @@ MATH(EXPR LIBSEDML_VERSION_NUMERIC "${LIBSEDML_VERSION_MAJOR} * 10000 + ${LIBSED
 set(PACKAGE_VERSION "${LIBSEDML_VERSION_MAJOR}.${LIBSEDML_VERSION_MINOR}.${LIBSEDML_VERSION_PATCH}${LIBSEDML_VERSION_RELEASE}")
 set(PACKAGE_NAME "libSEDML")
 
+# PACKAGE_VERSION gets overridden by using other packages, so setting
+# the PROJECT_VERSION, which will be used when exporting targets in
+# src/CMakeLists.txt
+set(PROJECT_VERSION ${PACKAGE_VERSION})
+
 # add make dist and make check target as they are already familiar for
 # everyone using the gnumake build
 add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
@@ -257,22 +262,27 @@ endif(WITH_SWIG)
 #
 # Locate libsbml
 #
-find_library(LIBSBML_LIBRARY
-    NAMES libsbml-static.lib sbml-static libsbml.lib sbml
-    PATHS ${LIBSEDML_DEPENDENCY_DIR}/lib
-    /usr/local/lib          
-          /usr/lib 
-    DOC "The file name of the sbml library."
-)
+find_package(sbml-static CONFIG REQUIRED)
+find_package(numl-static CONFIG REQUIRED)
+find_package(ZLIB ${ZLIB_VERSION} CONFIG REQUIRED)
+find_package(LibXml2 ${ZLIB_VERSION} CONFIG REQUIRED)
 
-find_path(LIBSBML_INCLUDE_DIR
-    NAMES sbml/SBase.h
-    PATHS 
-          ${LIBSEDML_DEPENDENCY_DIR}/include
-    /usr/local/include
-          /usr/include 
-    DOC "The directory containing the sbml include files."
-)
+#find_library(LIBSBML_LIBRARY
+#    NAMES libsbml-static.lib sbml-static libsbml.lib sbml
+#    PATHS ${LIBSEDML_DEPENDENCY_DIR}/lib
+#    /usr/local/lib
+#          /usr/lib
+#    DOC "The file name of the sbml library."
+#)
+
+#find_path(LIBSBML_INCLUDE_DIR
+#    NAMES sbml/SBase.h
+#    PATHS
+#          ${LIBSEDML_DEPENDENCY_DIR}/include
+#    /usr/local/include
+#          /usr/include
+#    DOC "The directory containing the sbml include files."
+#)
 
 set(LIBSBML_STATIC OFF CACHE BOOL "is libsbml statically compiled")
 if (WIN32 AND NOT CYGWIN)
@@ -283,30 +293,30 @@ if (WIN32 AND NOT CYGWIN)
   endif()
 endif()
 
-if(NOT EXISTS "${LIBSBML_INCLUDE_DIR}/sbml/SBase.h")
-    message(FATAL_ERROR 
-"The include directory specified for sbml appears to be invalid.  It should contain the 
-file sbml/SBase.h, but it does not. Please specify the LIBSBML_INCLUDE_DIR variable."
-)
-endif()
+#if(NOT EXISTS "${LIBSBML_INCLUDE_DIR}/sbml/SBase.h")
+#    message(FATAL_ERROR
+#"The include directory specified for sbml appears to be invalid.  It should contain the
+#file sbml/SBase.h, but it does not. Please specify the LIBSBML_INCLUDE_DIR variable."
+#)
+#endif()
 
 
-find_library(LIBNUML_LIBRARY
-    NAMES libnuml-static.lib numl-static libnuml.lib numl
-    PATHS ${LIBSEDML_DEPENDENCY_DIR}/lib
-    /usr/local/lib          
-          /usr/lib 
-    DOC "The file name of the numl library."
-)
+#find_library(LIBNUML_LIBRARY
+#    NAMES libnuml-static.lib numl-static libnuml.lib numl
+#    PATHS ${LIBSEDML_DEPENDENCY_DIR}/lib
+#    /usr/local/lib
+#          /usr/lib
+#    DOC "The file name of the numl library."
+#)
 
-find_path(LIBNUML_INCLUDE_DIR
-    NAMES numl/NMBase.h
-    PATHS 
-          ${LIBSEDML_DEPENDENCY_DIR}/include
-    /usr/local/include
-          /usr/include 
-    DOC "The directory containing the numl include files."
-)
+#find_path(LIBNUML_INCLUDE_DIR
+#    NAMES numl/NMBase.h
+#    PATHS
+#          ${LIBSEDML_DEPENDENCY_DIR}/include
+#    /usr/local/include
+#          /usr/include
+#    DOC "The directory containing the numl include files."
+#)
 
 set(LIBNUML_STATIC OFF CACHE BOOL "is libnuml statically compiled")
 if (WIN32 AND NOT CYGWIN)
@@ -324,7 +334,7 @@ endif()
 # list of additional files to link against.
 #
 
-set(EXTRA_LIBS "" CACHE STRING "List of additional libraries to link against." )
+set(EXTRA_LIBS "numl-static;sbml-static;xml2;zlib" CACHE STRING "List of additional libraries to link against." )
 set(EXTRA_INCLUDE "" CACHE STRING "List of additional include directories to add." )
 set(EXTRA_DEFS "" CACHE STRING "List of additional flag to add." )
 
@@ -334,46 +344,46 @@ set(EXTRA_DEFS "" CACHE STRING "List of additional flag to add." )
 # Locate zlib
 #
 
-set(ZLIB_INITIAL_VALUE)
-find_library(LIBZ_LIBRARY
-    NAMES zdll.lib z zlib.lib
-    PATHS /usr/lib /usr/local/lib
-          ${LIBSEDML_DEPENDENCY_DIR}/lib
-    DOC "The file name of the zip compression library."
-    )
+set(ZLIB_INITIAL_VALUE ON)
+#find_library(LIBZ_LIBRARY
+#    NAMES zdll.lib z zlib.lib
+#    PATHS /usr/lib /usr/local/lib
+#          ${LIBSEDML_DEPENDENCY_DIR}/lib
+#    DOC "The file name of the zip compression library."
+#    )
 
-if(EXISTS ${LIBZ_LIBRARY})
-    set(ZLIB_INITIAL_VALUE ON)
-else()
-    set(ZLIB_INITIAL_VALUE OFF)
-endif()
+#if(EXISTS ${LIBZ_LIBRARY})
+#    set(ZLIB_INITIAL_VALUE ON)
+#else()
+#    set(ZLIB_INITIAL_VALUE OFF)
+#endif()
 option(WITH_ZLIB     "Enable the use of zip compression."    ${ZLIB_INITIAL_VALUE} )
 
 if(WITH_ZLIB)
 
-    find_path(LIBZ_INCLUDE_DIR
-        NAMES zlib.h zlib/zlib.h
-        PATHS /usr/include /usr/local/include
-              ${LIBSEDML_DEPENDENCY_DIR}/include
-        DOC "The directory containing the zlib include files."
-              )
+#    find_path(LIBZ_INCLUDE_DIR
+#        NAMES zlib.h zlib/zlib.h
+#        PATHS /usr/include /usr/local/include
+#              ${LIBSEDML_DEPENDENCY_DIR}/include
+#        DOC "The directory containing the zlib include files."
+#              )
 
     add_definitions( -DUSE_ZLIB )
 
-    # make sure that we have a valid zip library
-    check_library_exists("${LIBZ_LIBRARY}" "gzopen" "" LIBZ_FOUND_SYMBOL)
-    if(NOT LIBZ_FOUND_SYMBOL)
-        # this is odd, but on windows this check always fails! must be a
-        # bug in the current cmake version so for now only issue this
-        # warning on linux
-        if(UNIX)
-            message(WARNING "The zlib library does not appear to be valid because it is missing certain required symbols. Please check that ${LIBZ_LIBRARY} is the zlib library. For details about the error, please see ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log")
-        endif()
-    endif()
+#    # make sure that we have a valid zip library
+#    check_library_exists("${LIBZ_LIBRARY}" "gzopen" "" LIBZ_FOUND_SYMBOL)
+#    if(NOT LIBZ_FOUND_SYMBOL)
+#        # this is odd, but on windows this check always fails! must be a
+#        # bug in the current cmake version so for now only issue this
+#        # warning on linux
+#        if(UNIX)
+#            message(WARNING "The zlib library does not appear to be valid because it is missing certain required symbols. Please check that ${LIBZ_LIBRARY} is the zlib library. For details about the error, please see ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log")
+#        endif()
+#    endif()
 
-    if(NOT EXISTS "${LIBZ_INCLUDE_DIR}/zlib.h")
-        message(FATAL_ERROR "The zlib include directory does not appear to be valid. It should contain the file zlib.h, but it does not.")
-    endif()
+#    if(NOT EXISTS "${LIBZ_INCLUDE_DIR}/zlib.h")
+#        message(FATAL_ERROR "The zlib include directory does not appear to be valid. It should contain the file zlib.h, but it does not.")
+#    endif()
 
 endif(WITH_ZLIB)
 

--- a/sedml/CMakeLists.txt
+++ b/sedml/CMakeLists.txt
@@ -155,6 +155,9 @@ endif(MSVC)
 # Build library
 #
 
+# used to create CMake config files for projects using this library
+include(CMakePackageConfigHelpers)
+
 if (NOT LIBSEDML_SKIP_SHARED_LIBRARY)
 
 add_library (${LIBSEDML_LIBRARY} SHARED ${LIBSEDML_SOURCES} )
@@ -168,11 +171,19 @@ endif()
 
 target_link_libraries(${LIBSEDML_LIBRARY} ${LIBSBML_LIBRARY} ${LIBNUML_LIBRARY} ${EXTRA_LIBS})
 
-INSTALL(TARGETS ${LIBSEDML_LIBRARY}
+# Create the exported target
+INSTALL(TARGETS ${LIBSEDML_LIBRARY} EXPORT ${LIBSEDML_LIBRARY}-config
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION include
   )
+
+# and install the exported target configuration
+install(EXPORT ${LIBSEDML_LIBRARY}-config DESTINATION ${PACKAGE_CONFIG_DIR})
+WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_CURRENT_BINARY_DIR}/${LIBSEDML_LIBRARY}-config-version.cmake COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIBSEDML_LIBRARY}-config-version.cmake
+    DESTINATION ${PACKAGE_CONFIG_DIR})
 
 endif()
 
@@ -184,8 +195,16 @@ endif(WIN32 AND NOT CYGWIN)
 
 target_link_libraries(${LIBSEDML_LIBRARY}-static ${LIBSBML_LIBRARY} ${LIBNUML_LIBRARY} ${EXTRA_LIBS})
 
-INSTALL(TARGETS ${LIBSEDML_LIBRARY}-static
+# Create the exported target for the static library
+INSTALL(TARGETS ${LIBSEDML_LIBRARY}-static EXPORT ${LIBSEDML_LIBRARY}-static-config
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
   ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  INCLUDES DESTINATION include
   )
+
+# and install the exported target configuration
+install(EXPORT ${LIBSEDML_LIBRARY}-static-config DESTINATION ${PACKAGE_CONFIG_DIR})
+WRITE_BASIC_PACKAGE_VERSION_FILE(${CMAKE_CURRENT_BINARY_DIR}/${LIBSEDML_LIBRARY}-static-config-version.cmake COMPATIBILITY AnyNewerVersion)
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/${LIBSEDML_LIBRARY}-static-config-version.cmake
+    DESTINATION ${PACKAGE_CONFIG_DIR})

--- a/sedml/common/libsedml-namespace.h.cmake
+++ b/sedml/common/libsedml-namespace.h.cmake
@@ -44,6 +44,10 @@
 
 LIBSBML_CPP_NAMESPACE_USE
 
+#include <numl/common/libnuml-namespace.h>
+
+LIBNUML_CPP_NAMESPACE_USE
+
 #endif
 
 /*

--- a/sedml/common/sedmlfwd.h
+++ b/sedml/common/sedmlfwd.h
@@ -333,8 +333,6 @@ typedef CLASS_OR_STRUCT SedDataSet                     SedDataSet_t;
 */
 typedef CLASS_OR_STRUCT SedDataDescription                     SedDataDescription_t;
 
-typedef CLASS_OR_STRUCT DimensionDescription                     DimensionDescription_t;
-
 /**
 * @var typedef class SedDataSource SedDataSource_t
 * @copydoc SedDataSource
@@ -349,6 +347,12 @@ typedef CLASS_OR_STRUCT SedSlice                     SedSlice_t;
 
 
 LIBSEDML_CPP_NAMESPACE_END
+
+LIBNUML_CPP_NAMESPACE_BEGIN
+
+typedef CLASS_OR_STRUCT DimensionDescription                     DimensionDescription_t;
+
+LIBNUML_CPP_NAMESPACE_END
 
 LIBSBML_CPP_NAMESPACE_BEGIN
 


### PR DESCRIPTION
I wanted to get libSEDML into a consistent framework where I use CMake to manage my dependencies as CMake external projects. See https://github.com/nickerso/get-configured/blob/master/CMakeLists.txt for the code.

To do this in a way that fits with other dependencies I have, I wanted to be able to use the standard CMake config mode `find_package`. This requires adding in a bit of extra CMake code to export the libSEDML targets so that they can be used as imported targets. I find this greatly eases the handling of dependencies, include paths, etc. This had the cascading effect that I needed to do the same things for [libSBML](https://github.com/nickerso/get-libsbml/tree/libsbml-5.13.0) and [libNuML](https://github.com/nickerso/NuML/tree/get-configured).

Not sure if this is useful to anyone else, but thought I'd better do the pull request just in case :) So far I have only tested this work on macOS 10.12.1, but previously this has worked across mac, windows, and linux with other dependencies.