### PR TITLE
Bug in the python bindings for functions which need transfer of ownership

### DIFF
--- a/bindings/python/local.i
+++ b/bindings/python/local.i
@@ -378,29 +378,17 @@ METHOD_NAME
 // ListOf
 // ----------------------------------------------------------------------
 
-//#if SWIG_VERSION > 0x010336
 TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),item)
-//#else
-//TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),1)
-//#endif
 
 // ----------------------------------------------------------------------
 // ASTNode
 // ----------------------------------------------------------------------
 
-//#if SWIG_VERSION > 0x010336
 TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),disownedChild)
 TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),disownedChild)
 TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),disownedChild)
 TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),disownedChild)
 TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),disownedAnnotation)
-//#else
-//TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),1)
-//TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),1)
-//TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),2)
-//TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),2)
-//TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),1)
-//#endif
 
 /**
  *

--- a/bindings/python/local.i
+++ b/bindings/python/local.i
@@ -366,11 +366,11 @@ SWIGPYTHON__CMP__(XMLOutputStream)
  * owned by that ListOf.
  */
 
-%define TAKEOVER_OWNERSHIP(METHOD_NAME,ARG_INDEX)
+%define TAKEOVER_OWNERSHIP(METHOD_NAME,ARG)
 %feature("pythonprepend")
 METHOD_NAME
 %{
-        if args[ARG_INDEX] is not None: args[ARG_INDEX].thisown = 0
+        if ARG is not None: ARG.thisown = 0
 %}
 %enddef
 
@@ -378,29 +378,29 @@ METHOD_NAME
 // ListOf
 // ----------------------------------------------------------------------
 
-#if SWIG_VERSION > 0x010336
-TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),0)
-#else
-TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),1)
-#endif
+//#if SWIG_VERSION > 0x010336
+TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),item)
+//#else
+//TAKEOVER_OWNERSHIP(ListOf::appendAndOwn(SedBase*),1)
+//#endif
 
 // ----------------------------------------------------------------------
 // ASTNode
 // ----------------------------------------------------------------------
 
-#if SWIG_VERSION > 0x010336
-TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),0)
-TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),0)
-TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),1)
-TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),1)
-TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),0)
-#else
-TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),1)
-TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),1)
-TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),2)
-TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),2)
-TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),1)
-#endif
+//#if SWIG_VERSION > 0x010336
+TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),disownedChild)
+TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),disownedChild)
+TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),disownedChild)
+TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),disownedChild)
+TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),disownedAnnotation)
+//#else
+//TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),1)
+//TAKEOVER_OWNERSHIP(ASTNode::prependChild(ASTNode*),1)
+//TAKEOVER_OWNERSHIP(ASTNode::insertChild(unsigned int, ASTNode*),2)
+//TAKEOVER_OWNERSHIP(ASTNode::replaceChild(unsigned int, ASTNode*),2)
+//TAKEOVER_OWNERSHIP(ASTNode::addSemanticsAnnotation(XMLNode*),1)
+//#endif
 
 /**
  *
@@ -874,4 +874,3 @@ SedNamespaces::getSupportedNamespaces
 #endif
                                SWIG_POINTER_OWN |  0 );
 }
- 


### PR DESCRIPTION
Hi Frank, 

I found a bug in the python bindings generation, while working with ASTNodes.
If I understand correctly, for certain functions, ownership of the object has to be transfered to the container the object is added to (for example an ASTNode added as the child of another ASTNode). To achieve this, the swig macro TAKEOVER_OWNERSHIP is inserting python codes into these functions. 

The code that is inserted is producing a bug, here is an example : 

    def addChild(self, disownedChild, inRead=False):
        """
        addChild(ASTNode self, ASTNode disownedChild, bool inRead=False) -> int
        addChild(ASTNode self, ASTNode disownedChild) -> int
        """

        if args[0] is not None: args[0].thisown = 0


        return _libsedml.ASTNode_addChild(self, disownedChild, inRead)

I guess this macro was written at a time where the produced arguments would be args*.
The easy fix is to rewrite the macro as such with the parameter name as the argument : 

    %define TAKEOVER_OWNERSHIP(METHOD_NAME,ARG)
    %feature("pythonprepend")
    METHOD_NAME
    %{
            if ARG is not None: ARG.thisown = 0
    %}
    %enddef

and to change the calls from this 

    TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),0)

to this 

    TAKEOVER_OWNERSHIP(ASTNode::addChild(ASTNode*),disownedChild)

This should work for all Swig version, so I also removed the version-specific calls.

