### PR TITLE
L1v4 numberOfPoints vs. numberOfSteps change.

### DIFF
--- a/src/sedml/SedErrorTable.h
+++ b/src/sedml/SedErrorTable.h
@@ -1081,7 +1081,7 @@ static const sedmlErrorTableEntry sedmlErrorTable[] =
     LIBSEDML_SEV_ERROR,
     "An <uniformTimeCourse> object must have the required attributes "
     "'sedml:initialTime', 'sedml:outputStartTime' and 'sedml:outputEndTime', "
-    "and may have the optional attributes 'sedml:numberOfPoints' and "
+    "and may have one of the optional attributes 'sedml:numberOfPoints' or "
     "'sedml:numberOfSteps'. No other attributes from the SBML Level 3 SEDML "
     "namespaces are permitted on an <uniformTimeCourse> object. ",
     { "L3V1 Sedml V1 Section"

--- a/src/sedml/SedUniformRange.cpp
+++ b/src/sedml/SedUniformRange.cpp
@@ -57,8 +57,8 @@ SedUniformRange::SedUniformRange(unsigned int level, unsigned int version)
   , mIsSetStart (false)
   , mEnd (util_NaN())
   , mIsSetEnd (false)
-  , mNumberOfPoints (SEDML_INT_MAX)
-  , mIsSetNumberOfPoints (false)
+  , mNumberOfSteps (SEDML_INT_MAX)
+  , mIsSetNumberOfSteps (false)
   , mType ("")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
@@ -75,8 +75,8 @@ SedUniformRange::SedUniformRange(SedNamespaces *sedmlns)
   , mIsSetStart (false)
   , mEnd (util_NaN())
   , mIsSetEnd (false)
-  , mNumberOfPoints (SEDML_INT_MAX)
-  , mIsSetNumberOfPoints (false)
+  , mNumberOfSteps (SEDML_INT_MAX)
+  , mIsSetNumberOfSteps (false)
   , mType ("")
 {
   setElementNamespace(sedmlns->getURI());
@@ -92,8 +92,8 @@ SedUniformRange::SedUniformRange(const SedUniformRange& orig)
   , mIsSetStart ( orig.mIsSetStart )
   , mEnd ( orig.mEnd )
   , mIsSetEnd ( orig.mIsSetEnd )
-  , mNumberOfPoints ( orig.mNumberOfPoints )
-  , mIsSetNumberOfPoints ( orig.mIsSetNumberOfPoints )
+  , mNumberOfSteps ( orig.mNumberOfSteps )
+  , mIsSetNumberOfSteps ( orig.mIsSetNumberOfSteps )
   , mType ( orig.mType )
 {
 }
@@ -112,8 +112,8 @@ SedUniformRange::operator=(const SedUniformRange& rhs)
     mIsSetStart = rhs.mIsSetStart;
     mEnd = rhs.mEnd;
     mIsSetEnd = rhs.mIsSetEnd;
-    mNumberOfPoints = rhs.mNumberOfPoints;
-    mIsSetNumberOfPoints = rhs.mIsSetNumberOfPoints;
+    mNumberOfSteps = rhs.mNumberOfSteps;
+    mIsSetNumberOfSteps = rhs.mIsSetNumberOfSteps;
     mType = rhs.mType;
   }
 
@@ -160,12 +160,22 @@ SedUniformRange::getEnd() const
 
 
 /*
- * Returns the value of the "numberOfPoints" attribute of this SedUniformRange.
+ * Returns the value of the "numberOfSteps" attribute of this SedUniformRange.
  */
 int
 SedUniformRange::getNumberOfPoints() const
 {
-  return mNumberOfPoints;
+  return mNumberOfSteps;
+}
+
+
+/*
+ * Returns the value of the "numberOfSteps" attribute of this SedUniformRange.
+ */
+int
+SedUniformRange::getNumberOfSteps() const
+{
+    return mNumberOfSteps;
 }
 
 
@@ -202,13 +212,24 @@ SedUniformRange::isSetEnd() const
 
 
 /*
- * Predicate returning @c true if this SedUniformRange's "numberOfPoints"
+ * Predicate returning @c true if this SedUniformRange's "numberOfSteps"
  * attribute is set.
  */
 bool
 SedUniformRange::isSetNumberOfPoints() const
 {
-  return mIsSetNumberOfPoints;
+  return mIsSetNumberOfSteps;
+}
+
+
+/*
+ * Predicate returning @c true if this SedUniformRange's "numberOfSteps"
+ * attribute is set.
+ */
+bool
+SedUniformRange::isSetNumberOfSteps() const
+{
+    return mIsSetNumberOfSteps;
 }
 
 
@@ -248,14 +269,26 @@ SedUniformRange::setEnd(double end)
 
 
 /*
- * Sets the value of the "numberOfPoints" attribute of this SedUniformRange.
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange.
  */
 int
-SedUniformRange::setNumberOfPoints(int numberOfPoints)
+SedUniformRange::setNumberOfPoints(int numberOfSteps)
 {
-  mNumberOfPoints = numberOfPoints;
-  mIsSetNumberOfPoints = true;
+  mNumberOfSteps = numberOfSteps;
+  mIsSetNumberOfSteps = true;
   return LIBSEDML_OPERATION_SUCCESS;
+}
+
+
+/*
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange.
+ */
+int
+SedUniformRange::setNumberOfSteps(int numberOfSteps)
+{
+    mNumberOfSteps = numberOfSteps;
+    mIsSetNumberOfSteps = true;
+    return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -311,15 +344,15 @@ SedUniformRange::unsetEnd()
 
 
 /*
- * Unsets the value of the "numberOfPoints" attribute of this SedUniformRange.
+ * Unsets the value of the "numberOfSteps" attribute of this SedUniformRange.
  */
 int
 SedUniformRange::unsetNumberOfPoints()
 {
-  mNumberOfPoints = SEDML_INT_MAX;
-  mIsSetNumberOfPoints = false;
+  mNumberOfSteps = SEDML_INT_MAX;
+  mIsSetNumberOfSteps = false;
 
-  if (isSetNumberOfPoints() == false)
+  if (isSetNumberOfSteps() == false)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -327,6 +360,26 @@ SedUniformRange::unsetNumberOfPoints()
   {
     return LIBSEDML_OPERATION_FAILED;
   }
+}
+
+
+/*
+ * Unsets the value of the "numberOfSteps" attribute of this SedUniformRange.
+ */
+int
+SedUniformRange::unsetNumberOfSteps()
+{
+    mNumberOfSteps = SEDML_INT_MAX;
+    mIsSetNumberOfSteps = false;
+
+    if (isSetNumberOfSteps() == false)
+    {
+        return LIBSEDML_OPERATION_SUCCESS;
+    }
+    else
+    {
+        return LIBSEDML_OPERATION_FAILED;
+    }
 }
 
 
@@ -389,7 +442,7 @@ SedUniformRange::hasRequiredAttributes() const
     allPresent = false;
   }
 
-  if (isSetNumberOfPoints() == false)
+  if (isSetNumberOfSteps() == false)
   {
     allPresent = false;
   }
@@ -484,9 +537,9 @@ SedUniformRange::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "numberOfPoints")
+  if (attributeName == "numberOfSteps" || attributeName == "numberOfPoints")
   {
-    value = getNumberOfPoints();
+    value = getNumberOfSteps();
     return_value = LIBSEDML_OPERATION_SUCCESS;
   }
 
@@ -597,9 +650,9 @@ SedUniformRange::isSetAttribute(const std::string& attributeName) const
   {
     value = isSetEnd();
   }
-  else if (attributeName == "numberOfPoints")
+  else if (attributeName == "numberOfSteps" || attributeName == "numberOfPoints")
   {
-    value = isSetNumberOfPoints();
+    value = isSetNumberOfSteps();
   }
   else if (attributeName == "type")
   {
@@ -640,9 +693,9 @@ SedUniformRange::setAttribute(const std::string& attributeName, int value)
 {
   int return_value = SedRange::setAttribute(attributeName, value);
 
-  if (attributeName == "numberOfPoints")
+  if (attributeName == "numberOfSteps" || attributeName == "numberOfPoints")
   {
-    return_value = setNumberOfPoints(value);
+    return_value = setNumberOfSteps(value);
   }
 
   return return_value;
@@ -737,9 +790,9 @@ SedUniformRange::unsetAttribute(const std::string& attributeName)
   {
     value = unsetEnd();
   }
-  else if (attributeName == "numberOfPoints")
+  else if (attributeName == "numberOfSteps" || attributeName == "numberOfPoints")
   {
-    value = unsetNumberOfPoints();
+    value = unsetNumberOfSteps();
   }
   else if (attributeName == "type")
   {
@@ -788,7 +841,7 @@ SedUniformRange::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 
   attributes.add("end");
 
-  attributes.add("numberOfPoints");
+  attributes.add("numberOfSteps");
 
   attributes.add("type");
 }
@@ -888,27 +941,32 @@ SedUniformRange::readAttributes(
   }
 
   // 
-  // numberOfPoints int (use = "required" )
+  // numberOfSteps int (use = "required" )
   // 
 
   numErrs = log ? log->getNumErrors() : 0;
-  mIsSetNumberOfPoints = attributes.readInto("numberOfPoints",
-    mNumberOfPoints);
+  mIsSetNumberOfSteps = attributes.readInto("numberOfSteps",
+    mNumberOfSteps);
 
-  if ( mIsSetNumberOfPoints == false && log)
+  if (!mIsSetNumberOfSteps) {
+      mIsSetNumberOfSteps = attributes.readInto("numberOfPoints",
+          mNumberOfSteps);
+  }
+
+  if ( mIsSetNumberOfSteps == false && log)
   {
     if (log && log->getNumErrors() == numErrs + 1 &&
       log->contains(XMLAttributeTypeMismatch))
     {
       log->remove(XMLAttributeTypeMismatch);
-      std::string message = "Sedml attribute 'numberOfPoints' from the "
+      std::string message = "Sedml attribute 'numberOfSteps' from the "
         "<SedUniformRange> element must be an integer.";
       log->logError(SedmlUniformRangeNumberOfPointsMustBeInteger, level,
         version, message, getLine(), getColumn());
     }
     else
     {
-      std::string message = "Sedml attribute 'numberOfPoints' is missing from "
+      std::string message = "Sedml attribute 'numberOfSteps' is missing from "
         "the <SedUniformRange> element.";
       log->logError(SedmlUniformRangeAllowedAttributes, level, version,
         message, getLine(), getColumn());
@@ -965,9 +1023,14 @@ SedUniformRange::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
     stream.writeAttribute("end", getPrefix(), mEnd);
   }
 
-  if (isSetNumberOfPoints() == true)
+  if (isSetNumberOfSteps() == true)
   {
-    stream.writeAttribute("numberOfPoints", getPrefix(), mNumberOfPoints);
+      if (getVersion() >= 4 || getLevel() > 1) {
+          stream.writeAttribute("numberOfSteps", getPrefix(), mNumberOfSteps);
+      }
+      else {
+          stream.writeAttribute("numberOfPoints", getPrefix(), mNumberOfSteps);
+      }
   }
 
   if (isSetType() == true)
@@ -1051,7 +1114,7 @@ SedUniformRange_getEnd(const SedUniformRange_t * sur)
 
 
 /*
- * Returns the value of the "numberOfPoints" attribute of this
+ * Returns the value of the "numberOfSteps" attribute of this
  * SedUniformRange_t.
  */
 LIBSEDML_EXTERN
@@ -1059,6 +1122,18 @@ int
 SedUniformRange_getNumberOfPoints(const SedUniformRange_t * sur)
 {
   return (sur != NULL) ? sur->getNumberOfPoints() : SEDML_INT_MAX;
+}
+
+
+/*
+ * Returns the value of the "numberOfSteps" attribute of this
+ * SedUniformRange_t.
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_getNumberOfSteps(const SedUniformRange_t* sur)
+{
+    return (sur != NULL) ? sur->getNumberOfSteps() : SEDML_INT_MAX;
 }
 
 
@@ -1103,7 +1178,7 @@ SedUniformRange_isSetEnd(const SedUniformRange_t * sur)
 
 
 /*
- * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfPoints"
+ * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfSteps"
  * attribute is set.
  */
 LIBSEDML_EXTERN
@@ -1111,6 +1186,18 @@ int
 SedUniformRange_isSetNumberOfPoints(const SedUniformRange_t * sur)
 {
   return (sur != NULL) ? static_cast<int>(sur->isSetNumberOfPoints()) : 0;
+}
+
+
+/*
+ * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfSteps"
+ * attribute is set.
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_isSetNumberOfSteps(const SedUniformRange_t* sur)
+{
+    return (sur != NULL) ? static_cast<int>(sur->isSetNumberOfSteps()) : 0;
 }
 
 
@@ -1149,14 +1236,26 @@ SedUniformRange_setEnd(SedUniformRange_t * sur, double end)
 
 
 /*
- * Sets the value of the "numberOfPoints" attribute of this SedUniformRange_t.
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange_t.
  */
 LIBSEDML_EXTERN
 int
-SedUniformRange_setNumberOfPoints(SedUniformRange_t * sur, int numberOfPoints)
+SedUniformRange_setNumberOfPoints(SedUniformRange_t * sur, int numberOfSteps)
 {
-  return (sur != NULL) ? sur->setNumberOfPoints(numberOfPoints) :
+  return (sur != NULL) ? sur->setNumberOfPoints(numberOfSteps) :
     LIBSEDML_INVALID_OBJECT;
+}
+
+
+/*
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange_t.
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_setNumberOfSteps(SedUniformRange_t* sur, int numberOfSteps)
+{
+    return (sur != NULL) ? sur->setNumberOfSteps(numberOfSteps) :
+        LIBSEDML_INVALID_OBJECT;
 }
 
 
@@ -1194,7 +1293,7 @@ SedUniformRange_unsetEnd(SedUniformRange_t * sur)
 
 
 /*
- * Unsets the value of the "numberOfPoints" attribute of this
+ * Unsets the value of the "numberOfSteps" attribute of this
  * SedUniformRange_t.
  */
 LIBSEDML_EXTERN
@@ -1202,6 +1301,18 @@ int
 SedUniformRange_unsetNumberOfPoints(SedUniformRange_t * sur)
 {
   return (sur != NULL) ? sur->unsetNumberOfPoints() : LIBSEDML_INVALID_OBJECT;
+}
+
+
+/*
+ * Unsets the value of the "numberOfSteps" attribute of this
+ * SedUniformRange_t.
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_unsetNumberOfSteps(SedUniformRange_t* sur)
+{
+    return (sur != NULL) ? sur->unsetNumberOfSteps() : LIBSEDML_INVALID_OBJECT;
 }
 
 

--- a/src/sedml/SedUniformRange.h
+++ b/src/sedml/SedUniformRange.h
@@ -67,8 +67,8 @@ protected:
   bool mIsSetStart;
   double mEnd;
   bool mIsSetEnd;
-  int mNumberOfPoints;
-  bool mIsSetNumberOfPoints;
+  int mNumberOfSteps;
+  bool mIsSetNumberOfSteps;
   std::string mType;
 
   /** @endcond */
@@ -152,13 +152,23 @@ public:
 
 
   /**
-   * Returns the value of the "numberOfPoints" attribute of this
+   * Returns the value of the "numberOfSteps" attribute of this
    * SedUniformRange.
    *
-   * @return the value of the "numberOfPoints" attribute of this
+   * @return the value of the "numberOfSteps" attribute of this
    * SedUniformRange as a integer.
    */
   int getNumberOfPoints() const;
+
+
+  /**
+   * Returns the value of the "numberOfSteps" attribute of this
+   * SedUniformRange.
+   *
+   * @return the value of the "numberOfSteps" attribute of this
+   * SedUniformRange as a integer.
+   */
+  int getNumberOfSteps() const;
 
 
   /**
@@ -191,13 +201,23 @@ public:
 
 
   /**
-   * Predicate returning @c true if this SedUniformRange's "numberOfPoints"
+   * Predicate returning @c true if this SedUniformRange's "numberOfSteps"
    * attribute is set.
    *
-   * @return @c true if this SedUniformRange's "numberOfPoints" attribute has
+   * @return @c true if this SedUniformRange's "numberOfSteps" attribute has
    * been set, otherwise @c false is returned.
    */
   bool isSetNumberOfPoints() const;
+
+
+  /**
+   * Predicate returning @c true if this SedUniformRange's "numberOfSteps"
+   * attribute is set.
+   *
+   * @return @c true if this SedUniformRange's "numberOfSteps" attribute has
+   * been set, otherwise @c false is returned.
+   */
+  bool isSetNumberOfSteps() const;
 
 
   /**
@@ -237,9 +257,9 @@ public:
 
 
   /**
-   * Sets the value of the "numberOfPoints" attribute of this SedUniformRange.
+   * Sets the value of the "numberOfSteps" attribute of this SedUniformRange.
    *
-   * @param numberOfPoints int value of the "numberOfPoints" attribute to be
+   * @param numberOfSteps int value of the "numberOfSteps" attribute to be
    * set.
    *
    * @copydetails doc_returns_success_code
@@ -247,7 +267,21 @@ public:
    * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
    * OperationReturnValues_t}
    */
-  int setNumberOfPoints(int numberOfPoints);
+  int setNumberOfPoints(int numberOfSteps);
+
+
+  /**
+   * Sets the value of the "numberOfSteps" attribute of this SedUniformRange.
+   *
+   * @param numberOfSteps int value of the "numberOfSteps" attribute to be
+   * set.
+   *
+   * @copydetails doc_returns_success_code
+   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
+   * OperationReturnValues_t}
+   */
+  int setNumberOfSteps(int numberOfSteps);
 
 
   /**
@@ -285,7 +319,7 @@ public:
 
 
   /**
-   * Unsets the value of the "numberOfPoints" attribute of this
+   * Unsets the value of the "numberOfSteps" attribute of this
    * SedUniformRange.
    *
    * @copydetails doc_returns_success_code
@@ -293,6 +327,17 @@ public:
    * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
    */
   int unsetNumberOfPoints();
+
+
+  /**
+   * Unsets the value of the "numberOfSteps" attribute of this
+   * SedUniformRange.
+   *
+   * @copydetails doc_returns_success_code
+   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
+   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
+   */
+  int unsetNumberOfSteps();
 
 
   /**
@@ -341,7 +386,7 @@ public:
    * @note The required attributes for the SedUniformRange object are:
    * @li "start"
    * @li "end"
-   * @li "numberOfPoints"
+   * @li "numberOfSteps"
    * @li "type"
    */
   virtual bool hasRequiredAttributes() const;
@@ -781,12 +826,12 @@ SedUniformRange_getEnd(const SedUniformRange_t * sur);
 
 
 /**
- * Returns the value of the "numberOfPoints" attribute of this
+ * Returns the value of the "numberOfSteps" attribute of this
  * SedUniformRange_t.
  *
- * @param sur the SedUniformRange_t structure whose numberOfPoints is sought.
+ * @param sur the SedUniformRange_t structure whose numberOfSteps is sought.
  *
- * @return the value of the "numberOfPoints" attribute of this
+ * @return the value of the "numberOfSteps" attribute of this
  * SedUniformRange_t as a integer.
  *
  * @memberof SedUniformRange_t
@@ -794,6 +839,22 @@ SedUniformRange_getEnd(const SedUniformRange_t * sur);
 LIBSEDML_EXTERN
 int
 SedUniformRange_getNumberOfPoints(const SedUniformRange_t * sur);
+
+
+/**
+ * Returns the value of the "numberOfSteps" attribute of this
+ * SedUniformRange_t.
+ *
+ * @param sur the SedUniformRange_t structure whose numberOfSteps is sought.
+ *
+ * @return the value of the "numberOfSteps" attribute of this
+ * SedUniformRange_t as a integer.
+ *
+ * @memberof SedUniformRange_t
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_getNumberOfSteps(const SedUniformRange_t* sur);
 
 
 /**
@@ -846,12 +907,12 @@ SedUniformRange_isSetEnd(const SedUniformRange_t * sur);
 
 
 /**
- * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfPoints"
+ * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfSteps"
  * attribute is set.
  *
  * @param sur the SedUniformRange_t structure.
  *
- * @return @c 1 (true) if this SedUniformRange_t's "numberOfPoints" attribute
+ * @return @c 1 (true) if this SedUniformRange_t's "numberOfSteps" attribute
  * has been set, otherwise @c 0 (false) is returned.
  *
  * @memberof SedUniformRange_t
@@ -859,6 +920,22 @@ SedUniformRange_isSetEnd(const SedUniformRange_t * sur);
 LIBSEDML_EXTERN
 int
 SedUniformRange_isSetNumberOfPoints(const SedUniformRange_t * sur);
+
+
+/**
+ * Predicate returning @c 1 (true) if this SedUniformRange_t's "numberOfSteps"
+ * attribute is set.
+ *
+ * @param sur the SedUniformRange_t structure.
+ *
+ * @return @c 1 (true) if this SedUniformRange_t's "numberOfSteps" attribute
+ * has been set, otherwise @c 0 (false) is returned.
+ *
+ * @memberof SedUniformRange_t
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_isSetNumberOfSteps(const SedUniformRange_t* sur);
 
 
 /**
@@ -918,11 +995,11 @@ SedUniformRange_setEnd(SedUniformRange_t * sur, double end);
 
 
 /**
- * Sets the value of the "numberOfPoints" attribute of this SedUniformRange_t.
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange_t.
  *
  * @param sur the SedUniformRange_t structure.
  *
- * @param numberOfPoints int value of the "numberOfPoints" attribute to be set.
+ * @param numberOfSteps int value of the "numberOfSteps" attribute to be set.
  *
  * @copydetails doc_returns_success_code
  * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
@@ -935,7 +1012,28 @@ SedUniformRange_setEnd(SedUniformRange_t * sur, double end);
 LIBSEDML_EXTERN
 int
 SedUniformRange_setNumberOfPoints(SedUniformRange_t * sur,
-                                  int numberOfPoints);
+                                  int numberOfSteps);
+
+
+/**
+ * Sets the value of the "numberOfSteps" attribute of this SedUniformRange_t.
+ *
+ * @param sur the SedUniformRange_t structure.
+ *
+ * @param numberOfSteps int value of the "numberOfSteps" attribute to be set.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
+ * OperationReturnValues_t}
+ * @li @sedmlconstant{LIBSEDML_INVALID_OBJECT, OperationReturnValues_t}
+ *
+ * @memberof SedUniformRange_t
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_setNumberOfSteps(SedUniformRange_t* sur,
+    int numberOfSteps);
 
 
 /**
@@ -994,7 +1092,7 @@ SedUniformRange_unsetEnd(SedUniformRange_t * sur);
 
 
 /**
- * Unsets the value of the "numberOfPoints" attribute of this
+ * Unsets the value of the "numberOfSteps" attribute of this
  * SedUniformRange_t.
  *
  * @param sur the SedUniformRange_t structure.
@@ -1009,6 +1107,24 @@ SedUniformRange_unsetEnd(SedUniformRange_t * sur);
 LIBSEDML_EXTERN
 int
 SedUniformRange_unsetNumberOfPoints(SedUniformRange_t * sur);
+
+
+/**
+ * Unsets the value of the "numberOfSteps" attribute of this
+ * SedUniformRange_t.
+ *
+ * @param sur the SedUniformRange_t structure.
+ *
+ * @copydetails doc_returns_success_code
+ * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
+ * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
+ * @li @sedmlconstant{LIBSEDML_INVALID_OBJECT, OperationReturnValues_t}
+ *
+ * @memberof SedUniformRange_t
+ */
+LIBSEDML_EXTERN
+int
+SedUniformRange_unsetNumberOfSteps(SedUniformRange_t* sur);
 
 
 /**
@@ -1041,7 +1157,7 @@ SedUniformRange_unsetType(SedUniformRange_t * sur);
  * @note The required attributes for the SedUniformRange_t object are:
  * @li "start"
  * @li "end"
- * @li "numberOfPoints"
+ * @li "numberOfSteps"
  * @li "type"
  *
  * @memberof SedUniformRange_t

--- a/src/sedml/SedUniformTimeCourse.cpp
+++ b/src/sedml/SedUniformTimeCourse.cpp
@@ -60,8 +60,6 @@ SedUniformTimeCourse::SedUniformTimeCourse(unsigned int level,
   , mIsSetOutputStartTime (false)
   , mOutputEndTime (util_NaN())
   , mIsSetOutputEndTime (false)
-  , mNumberOfPoints (SEDML_INT_MAX)
-  , mIsSetNumberOfPoints (false)
   , mNumberOfSteps (SEDML_INT_MAX)
   , mIsSetNumberOfSteps (false)
 {
@@ -81,8 +79,6 @@ SedUniformTimeCourse::SedUniformTimeCourse(SedNamespaces *sedmlns)
   , mIsSetOutputStartTime (false)
   , mOutputEndTime (util_NaN())
   , mIsSetOutputEndTime (false)
-  , mNumberOfPoints (SEDML_INT_MAX)
-  , mIsSetNumberOfPoints (false)
   , mNumberOfSteps (SEDML_INT_MAX)
   , mIsSetNumberOfSteps (false)
 {
@@ -101,8 +97,6 @@ SedUniformTimeCourse::SedUniformTimeCourse(const SedUniformTimeCourse& orig)
   , mIsSetOutputStartTime ( orig.mIsSetOutputStartTime )
   , mOutputEndTime ( orig.mOutputEndTime )
   , mIsSetOutputEndTime ( orig.mIsSetOutputEndTime )
-  , mNumberOfPoints ( orig.mNumberOfPoints )
-  , mIsSetNumberOfPoints ( orig.mIsSetNumberOfPoints )
   , mNumberOfSteps ( orig.mNumberOfSteps )
   , mIsSetNumberOfSteps ( orig.mIsSetNumberOfSteps )
 {
@@ -124,8 +118,6 @@ SedUniformTimeCourse::operator=(const SedUniformTimeCourse& rhs)
     mIsSetOutputStartTime = rhs.mIsSetOutputStartTime;
     mOutputEndTime = rhs.mOutputEndTime;
     mIsSetOutputEndTime = rhs.mIsSetOutputEndTime;
-    mNumberOfPoints = rhs.mNumberOfPoints;
-    mIsSetNumberOfPoints = rhs.mIsSetNumberOfPoints;
     mNumberOfSteps = rhs.mNumberOfSteps;
     mIsSetNumberOfSteps = rhs.mIsSetNumberOfSteps;
   }
@@ -186,13 +178,13 @@ SedUniformTimeCourse::getOutputEndTime() const
 
 
 /*
- * Returns the value of the "numberOfPoints" attribute of this
+ * Returns the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse.
  */
 int
 SedUniformTimeCourse::getNumberOfPoints() const
 {
-  return mNumberOfPoints;
+  return mNumberOfSteps;
 }
 
 
@@ -241,13 +233,13 @@ SedUniformTimeCourse::isSetOutputEndTime() const
 
 
 /*
- * Predicate returning @c true if this SedUniformTimeCourse's "numberOfPoints"
+ * Predicate returning @c true if this SedUniformTimeCourse's "numberOfSteps"
  * attribute is set.
  */
 bool
 SedUniformTimeCourse::isSetNumberOfPoints() const
 {
-  return mIsSetNumberOfPoints;
+  return mIsSetNumberOfSteps;
 }
 
 
@@ -305,10 +297,10 @@ SedUniformTimeCourse::setOutputEndTime(double outputEndTime)
  * SedUniformTimeCourse.
  */
 int
-SedUniformTimeCourse::setNumberOfPoints(int numberOfPoints)
+SedUniformTimeCourse::setNumberOfPoints(int numberOfSteps)
 {
-  mNumberOfPoints = numberOfPoints;
-  mIsSetNumberOfPoints = true;
+  mNumberOfSteps = numberOfSteps;
+  mIsSetNumberOfSteps = true;
   return LIBSEDML_OPERATION_SUCCESS;
 }
 
@@ -390,16 +382,16 @@ SedUniformTimeCourse::unsetOutputEndTime()
 
 
 /*
- * Unsets the value of the "numberOfPoints" attribute of this
+ * Unsets the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse.
  */
 int
 SedUniformTimeCourse::unsetNumberOfPoints()
 {
-  mNumberOfPoints = SEDML_INT_MAX;
-  mIsSetNumberOfPoints = false;
+  mNumberOfSteps= SEDML_INT_MAX;
+  mIsSetNumberOfSteps= false;
 
-  if (isSetNumberOfPoints() == false)
+  if (isSetNumberOfSteps() == false)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -563,12 +555,7 @@ SedUniformTimeCourse::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "numberOfPoints")
-  {
-    value = getNumberOfPoints();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "numberOfSteps")
+  if (attributeName == "numberOfPoints" || attributeName == "numberOfSteps")
   {
     value = getNumberOfSteps();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -682,11 +669,7 @@ SedUniformTimeCourse::isSetAttribute(const std::string& attributeName) const
   {
     value = isSetOutputEndTime();
   }
-  else if (attributeName == "numberOfPoints")
-  {
-    value = isSetNumberOfPoints();
-  }
-  else if (attributeName == "numberOfSteps")
+  else if (attributeName == "numberOfPoints" || attributeName == "numberOfSteps")
   {
     value = isSetNumberOfSteps();
   }
@@ -729,11 +712,7 @@ SedUniformTimeCourse::setAttribute(const std::string& attributeName,
 {
   int return_value = SedSimulation::setAttribute(attributeName, value);
 
-  if (attributeName == "numberOfPoints")
-  {
-    return_value = setNumberOfPoints(value);
-  }
-  else if (attributeName == "numberOfSteps")
+  if (attributeName == "numberOfPoints" || attributeName == "numberOfSteps")
   {
     return_value = setNumberOfSteps(value);
   }
@@ -838,11 +817,7 @@ SedUniformTimeCourse::unsetAttribute(const std::string& attributeName)
   {
     value = unsetOutputEndTime();
   }
-  else if (attributeName == "numberOfPoints")
-  {
-    value = unsetNumberOfPoints();
-  }
-  else if (attributeName == "numberOfSteps")
+  else if (attributeName == "numberOfPoints" || attributeName == "numberOfSteps")
   {
     value = unsetNumberOfSteps();
   }
@@ -893,7 +868,9 @@ SedUniformTimeCourse::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 
   attributes.add("numberOfPoints");
 
-  attributes.add("numberOfSteps");
+  if (getVersion() >= 4 || getLevel() > 1) {
+      attributes.add("numberOfSteps");
+  }
 }
 
 /** @endcond */
@@ -1019,32 +996,15 @@ SedUniformTimeCourse::readAttributes(
   }
 
   // 
-  // numberOfPoints int (use = "optional" )
-  // 
-
-  numErrs = log ? log->getNumErrors() : 0;
-  mIsSetNumberOfPoints = attributes.readInto("numberOfPoints",
-    mNumberOfPoints);
-
-  if ( mIsSetNumberOfPoints == false && log)
-  {
-    if (log && log->getNumErrors() == numErrs + 1 &&
-      log->contains(XMLAttributeTypeMismatch))
-    {
-      log->remove(XMLAttributeTypeMismatch);
-      std::string message = "Sedml attribute 'numberOfPoints' from the "
-        "<SedUniformTimeCourse> element must be an integer.";
-      log->logError(SedmlUniformTimeCourseNumberOfPointsMustBeInteger, level,
-        version, message, getLine(), getColumn());
-    }
-  }
-
-  // 
   // numberOfSteps int (use = "optional" )
   // 
 
   numErrs = log ? log->getNumErrors() : 0;
   mIsSetNumberOfSteps = attributes.readInto("numberOfSteps", mNumberOfSteps);
+
+  if (!mIsSetNumberOfSteps) {
+      mIsSetNumberOfSteps = attributes.readInto("numberOfPoints", mNumberOfSteps);
+  }
 
   if ( mIsSetNumberOfSteps == false && log)
   {
@@ -1090,14 +1050,14 @@ SedUniformTimeCourse::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
     stream.writeAttribute("outputEndTime", getPrefix(), mOutputEndTime);
   }
 
-  if (isSetNumberOfPoints() == true)
-  {
-    stream.writeAttribute("numberOfPoints", getPrefix(), mNumberOfPoints);
-  }
-
   if (isSetNumberOfSteps() == true)
   {
-    stream.writeAttribute("numberOfSteps", getPrefix(), mNumberOfSteps);
+      if (getVersion() >= 4 || getLevel() > 1) {
+          stream.writeAttribute("numberOfSteps", getPrefix(), mNumberOfSteps);
+      }
+      else {
+          stream.writeAttribute("numberOfPoints", getPrefix(), mNumberOfSteps);
+      }
   }
 }
 
@@ -1190,7 +1150,7 @@ SedUniformTimeCourse_getOutputEndTime(const SedUniformTimeCourse_t * sutc)
 
 
 /*
- * Returns the value of the "numberOfPoints" attribute of this
+ * Returns the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  */
 LIBSEDML_EXTERN
@@ -1251,7 +1211,7 @@ SedUniformTimeCourse_isSetOutputEndTime(const SedUniformTimeCourse_t * sutc)
 
 /*
  * Predicate returning @c 1 (true) if this SedUniformTimeCourse_t's
- * "numberOfPoints" attribute is set.
+ * "numberOfSteps" attribute is set.
  */
 LIBSEDML_EXTERN
 int
@@ -1316,15 +1276,15 @@ SedUniformTimeCourse_setOutputEndTime(SedUniformTimeCourse_t * sutc,
 
 
 /*
- * Sets the value of the "numberOfPoints" attribute of this
+ * Sets the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  */
 LIBSEDML_EXTERN
 int
 SedUniformTimeCourse_setNumberOfPoints(SedUniformTimeCourse_t * sutc,
-                                       int numberOfPoints)
+                                       int numberOfSteps)
 {
-  return (sutc != NULL) ? sutc->setNumberOfPoints(numberOfPoints) :
+  return (sutc != NULL) ? sutc->setNumberOfPoints(numberOfSteps) :
     LIBSEDML_INVALID_OBJECT;
 }
 
@@ -1381,7 +1341,7 @@ SedUniformTimeCourse_unsetOutputEndTime(SedUniformTimeCourse_t * sutc)
 
 
 /*
- * Unsets the value of the "numberOfPoints" attribute of this
+ * Unsets the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  */
 LIBSEDML_EXTERN

--- a/src/sedml/SedUniformTimeCourse.h
+++ b/src/sedml/SedUniformTimeCourse.h
@@ -69,8 +69,6 @@ protected:
   bool mIsSetOutputStartTime;
   double mOutputEndTime;
   bool mIsSetOutputEndTime;
-  int mNumberOfPoints;
-  bool mIsSetNumberOfPoints;
   int mNumberOfSteps;
   bool mIsSetNumberOfSteps;
 
@@ -167,10 +165,10 @@ public:
 
 
   /**
-   * Returns the value of the "numberOfPoints" attribute of this
+   * Returns the value of the "numberOfSteps" attribute of this
    * SedUniformTimeCourse.
    *
-   * @return the value of the "numberOfPoints" attribute of this
+   * @return the value of the "numberOfSteps" attribute of this
    * SedUniformTimeCourse as a integer.
    */
   int getNumberOfPoints() const;
@@ -218,9 +216,9 @@ public:
 
   /**
    * Predicate returning @c true if this SedUniformTimeCourse's
-   * "numberOfPoints" attribute is set.
+   * "numberOfSteps" attribute is set.
    *
-   * @return @c true if this SedUniformTimeCourse's "numberOfPoints" attribute
+   * @return @c true if this SedUniformTimeCourse's "numberOfSteps" attribute
    * has been set, otherwise @c false is returned.
    */
   bool isSetNumberOfPoints() const;
@@ -281,10 +279,10 @@ public:
 
 
   /**
-   * Sets the value of the "numberOfPoints" attribute of this
+   * Sets the value of the "numberOfSteps" attribute of this
    * SedUniformTimeCourse.
    *
-   * @param numberOfPoints int value of the "numberOfPoints" attribute to be
+   * @param numberOfSteps int value of the "numberOfSteps" attribute to be
    * set.
    *
    * @copydetails doc_returns_success_code
@@ -292,7 +290,7 @@ public:
    * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
    * OperationReturnValues_t}
    */
-  int setNumberOfPoints(int numberOfPoints);
+  int setNumberOfPoints(int numberOfSteps);
 
 
   /**
@@ -343,7 +341,7 @@ public:
 
 
   /**
-   * Unsets the value of the "numberOfPoints" attribute of this
+   * Unsets the value of the "numberOfSteps" attribute of this
    * SedUniformTimeCourse.
    *
    * @copydetails doc_returns_success_code
@@ -872,13 +870,13 @@ SedUniformTimeCourse_getOutputEndTime(const SedUniformTimeCourse_t * sutc);
 
 
 /**
- * Returns the value of the "numberOfPoints" attribute of this
+ * Returns the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  *
- * @param sutc the SedUniformTimeCourse_t structure whose numberOfPoints is
+ * @param sutc the SedUniformTimeCourse_t structure whose numberOfSteps is
  * sought.
  *
- * @return the value of the "numberOfPoints" attribute of this
+ * @return the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t as a integer.
  *
  * @memberof SedUniformTimeCourse_t
@@ -955,11 +953,11 @@ SedUniformTimeCourse_isSetOutputEndTime(const SedUniformTimeCourse_t * sutc);
 
 /**
  * Predicate returning @c 1 (true) if this SedUniformTimeCourse_t's
- * "numberOfPoints" attribute is set.
+ * "numberOfSteps" attribute is set.
  *
  * @param sutc the SedUniformTimeCourse_t structure.
  *
- * @return @c 1 (true) if this SedUniformTimeCourse_t's "numberOfPoints"
+ * @return @c 1 (true) if this SedUniformTimeCourse_t's "numberOfSteps"
  * attribute has been set, otherwise @c 0 (false) is returned.
  *
  * @memberof SedUniformTimeCourse_t
@@ -1054,12 +1052,12 @@ SedUniformTimeCourse_setOutputEndTime(SedUniformTimeCourse_t * sutc,
 
 
 /**
- * Sets the value of the "numberOfPoints" attribute of this
+ * Sets the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  *
  * @param sutc the SedUniformTimeCourse_t structure.
  *
- * @param numberOfPoints int value of the "numberOfPoints" attribute to be set.
+ * @param numberOfSteps int value of the "numberOfSteps" attribute to be set.
  *
  * @copydetails doc_returns_success_code
  * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
@@ -1072,7 +1070,7 @@ SedUniformTimeCourse_setOutputEndTime(SedUniformTimeCourse_t * sutc,
 LIBSEDML_EXTERN
 int
 SedUniformTimeCourse_setNumberOfPoints(SedUniformTimeCourse_t * sutc,
-                                       int numberOfPoints);
+                                       int numberOfSteps);
 
 
 /**
@@ -1152,7 +1150,7 @@ SedUniformTimeCourse_unsetOutputEndTime(SedUniformTimeCourse_t * sutc);
 
 
 /**
- * Unsets the value of the "numberOfPoints" attribute of this
+ * Unsets the value of the "numberOfSteps" attribute of this
  * SedUniformTimeCourse_t.
  *
  * @param sutc the SedUniformTimeCourse_t structure.


### PR DESCRIPTION
This change unifies the library so that it only stores 'numberOfSteps' in one place, reads either numberOfPoints or numberOfSteps, and writes numberOfPoints or numberOfSteps, depending on the level/version of the document.

This also adds this change to the 'UniformRange' object, where it was missed the first time through the spec.