### PR TITLE
Allow 'numberOfSteps' to be an expected attribute of UniformRange.

### DIFF
--- a/src/sedml/SedUniformRange.cpp
+++ b/src/sedml/SedUniformRange.cpp
@@ -790,6 +790,10 @@ SedUniformRange::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 
   attributes.add("numberOfPoints");
 
+  if (getVersion() >= 4 || getLevel() > 1) {
+      attributes.add("numberOfSteps");
+  }
+
   attributes.add("type");
 }
 


### PR DESCRIPTION
Forgot to modify the 'addExpectedAttributes' when updating the numberOfSteps/numberOfPoints adjustment between l1v3 and l1v4.