### PR TITLE
Move all id/name functions to SedBase.cpp

### DIFF
--- a/src/sedml/SedAbstractCurve.cpp
+++ b/src/sedml/SedAbstractCurve.cpp
@@ -57,7 +57,6 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedAbstractCurve::SedAbstractCurve(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mLogX (false)
   , mIsSetLogX (false)
   , mOrder (SEDML_INT_MAX)
@@ -68,6 +67,7 @@ SedAbstractCurve::SedAbstractCurve(unsigned int level, unsigned int version)
   , mElementName("abstractCurve")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -77,7 +77,6 @@ SedAbstractCurve::SedAbstractCurve(unsigned int level, unsigned int version)
  */
 SedAbstractCurve::SedAbstractCurve(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mLogX (false)
   , mIsSetLogX (false)
   , mOrder (SEDML_INT_MAX)
@@ -88,6 +87,7 @@ SedAbstractCurve::SedAbstractCurve(SedNamespaces *sedmlns)
   , mElementName("abstractCurve")
 {
   setElementNamespace(sedmlns->getURI());
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -96,7 +96,6 @@ SedAbstractCurve::SedAbstractCurve(SedNamespaces *sedmlns)
  */
 SedAbstractCurve::SedAbstractCurve(const SedAbstractCurve& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mLogX ( orig.mLogX )
   , mIsSetLogX ( orig.mIsSetLogX )
   , mOrder ( orig.mOrder )
@@ -118,7 +117,6 @@ SedAbstractCurve::operator=(const SedAbstractCurve& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mLogX = rhs.mLogX;
     mIsSetLogX = rhs.mIsSetLogX;
     mOrder = rhs.mOrder;
@@ -148,26 +146,6 @@ SedAbstractCurve::clone() const
  */
 SedAbstractCurve::~SedAbstractCurve()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedAbstractCurve.
- */
-const std::string&
-SedAbstractCurve::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedAbstractCurve.
- */
-const std::string&
-SedAbstractCurve::getName() const
-{
-  return mName;
 }
 
 
@@ -223,28 +201,6 @@ SedAbstractCurve::getXDataReference() const
 
 
 /*
- * Predicate returning @c true if this SedAbstractCurve's "id" attribute is
- * set.
- */
-bool
-SedAbstractCurve::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedAbstractCurve's "name" attribute is
- * set.
- */
-bool
-SedAbstractCurve::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedAbstractCurve's "logX" attribute is
  * set.
  */
@@ -296,28 +252,6 @@ bool
 SedAbstractCurve::isSetXDataReference() const
 {
   return (mXDataReference.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedAbstractCurve.
- */
-int
-SedAbstractCurve::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedAbstractCurve.
- */
-int
-SedAbstractCurve::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -388,44 +322,6 @@ SedAbstractCurve::setXDataReference(const std::string& xDataReference)
   {
     mXDataReference = xDataReference;
     return LIBSEDML_OPERATION_SUCCESS;
-  }
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedAbstractCurve.
- */
-int
-SedAbstractCurve::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedAbstractCurve.
- */
-int
-SedAbstractCurve::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
   }
 }
 
@@ -773,17 +669,7 @@ SedAbstractCurve::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "style")
+  if (attributeName == "style")
   {
     value = getStyle();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -817,15 +703,7 @@ SedAbstractCurve::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "logX")
+  if (attributeName == "logX")
   {
     value = isSetLogX();
   }
@@ -943,15 +821,7 @@ SedAbstractCurve::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "style")
+  if (attributeName == "style")
   {
     return_value = setStyle(value);
   }
@@ -981,15 +851,7 @@ SedAbstractCurve::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "logX")
+  if (attributeName == "logX")
   {
     value = unsetLogX();
   }
@@ -1027,10 +889,6 @@ SedAbstractCurve::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 
   attributes.add("logX");
 
@@ -1096,40 +954,6 @@ SedAbstractCurve::readAttributes(
         log->logError(SedmlAbstractCurveAllowedAttributes, level, version,
           details, getLine(), getColumn());
       }
-    }
-  }
-
-  // 
-  // id SId (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedAbstractCurve>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedAbstractCurve>");
     }
   }
 
@@ -1254,16 +1078,6 @@ SedAbstractCurve::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   XMLOutputStream& stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetLogX() == true)
   {

--- a/src/sedml/SedAbstractCurve.cpp
+++ b/src/sedml/SedAbstractCurve.cpp
@@ -68,6 +68,7 @@ SedAbstractCurve::SedAbstractCurve(unsigned int level, unsigned int version)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   mNameAllowedPreV4 = true;
+  mIdAllowedPreV4 = true;
 }
 
 
@@ -88,6 +89,7 @@ SedAbstractCurve::SedAbstractCurve(SedNamespaces *sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   mNameAllowedPreV4 = true;
+  mIdAllowedPreV4 = true;
 }
 
 

--- a/src/sedml/SedAbstractCurve.h
+++ b/src/sedml/SedAbstractCurve.h
@@ -66,7 +66,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   bool mLogX;
   bool mIsSetLogX;
   int mOrder;
@@ -139,24 +138,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedAbstractCurve.
-   *
-   * @return the value of the "id" attribute of this SedAbstractCurve as a
-   * string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedAbstractCurve.
-   *
-   * @return the value of the "name" attribute of this SedAbstractCurve as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "logX" attribute of this SedAbstractCurve.
    *
    * @return the value of the "logX" attribute of this SedAbstractCurve as a
@@ -200,26 +181,6 @@ public:
    * SedAbstractCurve as a string.
    */
   const std::string& getXDataReference() const;
-
-
-  /**
-   * Predicate returning @c true if this SedAbstractCurve's "id" attribute is
-   * set.
-   *
-   * @return @c true if this SedAbstractCurve's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedAbstractCurve's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedAbstractCurve's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -270,36 +231,6 @@ public:
    * been set, otherwise @c false is returned.
    */
   bool isSetXDataReference() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedAbstractCurve.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedAbstractCurve.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
 
 
   /**
@@ -367,26 +298,6 @@ public:
    * OperationReturnValues_t}
    */
   int setXDataReference(const std::string& xDataReference);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedAbstractCurve.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedAbstractCurve.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedAbstractTask.cpp
+++ b/src/sedml/SedAbstractTask.cpp
@@ -59,9 +59,10 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedAbstractTask::SedAbstractTask(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mElementName("task")
 {
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
 }
 
@@ -72,10 +73,11 @@ SedAbstractTask::SedAbstractTask(unsigned int level, unsigned int version)
  */
 SedAbstractTask::SedAbstractTask(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mElementName("task")
 {
   setElementNamespace(sedmlns->getURI());
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -84,7 +86,6 @@ SedAbstractTask::SedAbstractTask(SedNamespaces *sedmlns)
  */
 SedAbstractTask::SedAbstractTask(const SedAbstractTask& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mElementName ( orig.mElementName )
 {
 }
@@ -99,7 +100,6 @@ SedAbstractTask::operator=(const SedAbstractTask& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mElementName = rhs.mElementName;
   }
 
@@ -122,107 +122,6 @@ SedAbstractTask::clone() const
  */
 SedAbstractTask::~SedAbstractTask()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedAbstractTask.
- */
-const std::string&
-SedAbstractTask::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedAbstractTask.
- */
-const std::string&
-SedAbstractTask::getName() const
-{
-  return mName;
-}
-
-
-/*
- * Predicate returning @c true if this SedAbstractTask's "id" attribute is set.
- */
-bool
-SedAbstractTask::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedAbstractTask's "name" attribute is
- * set.
- */
-bool
-SedAbstractTask::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedAbstractTask.
- */
-int
-SedAbstractTask::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedAbstractTask.
- */
-int
-SedAbstractTask::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedAbstractTask.
- */
-int
-SedAbstractTask::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedAbstractTask.
- */
-int
-SedAbstractTask::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -458,17 +357,6 @@ SedAbstractTask::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-
   return return_value;
 }
 
@@ -486,15 +374,6 @@ bool
 SedAbstractTask::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
 
   return value;
 }
@@ -583,15 +462,6 @@ SedAbstractTask::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-
   return return_value;
 }
 
@@ -608,15 +478,6 @@ int
 SedAbstractTask::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
 
   return value;
 }
@@ -635,10 +496,6 @@ SedAbstractTask::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 }
 
 /** @endcond */
@@ -701,22 +558,7 @@ SedAbstractTask::readAttributes(
   // id SId (use = "required" )
   // 
 
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedAbstractTask>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if (!isSetId())
   {
     if (log)
     {
@@ -724,20 +566,6 @@ SedAbstractTask::readAttributes(
         "<SedAbstractTask> element.";
       log->logError(SedmlAbstractTaskAllowedAttributes, level, version,
         message, getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedAbstractTask>");
     }
   }
 }
@@ -756,16 +584,6 @@ SedAbstractTask::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   XMLOutputStream& stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 }
 
 /** @endcond */

--- a/src/sedml/SedAbstractTask.h
+++ b/src/sedml/SedAbstractTask.h
@@ -68,7 +68,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mElementName;
 
   /** @endcond */
@@ -132,93 +131,6 @@ public:
    */
   virtual ~SedAbstractTask();
 
-
-  /**
-   * Returns the value of the "id" attribute of this SedAbstractTask.
-   *
-   * @return the value of the "id" attribute of this SedAbstractTask as a
-   * string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedAbstractTask.
-   *
-   * @return the value of the "name" attribute of this SedAbstractTask as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
-   * Predicate returning @c true if this SedAbstractTask's "id" attribute is
-   * set.
-   *
-   * @return @c true if this SedAbstractTask's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedAbstractTask's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedAbstractTask's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedAbstractTask.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedAbstractTask.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedAbstractTask.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedAbstractTask.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedBase.cpp
+++ b/src/sedml/SedBase.cpp
@@ -1676,15 +1676,7 @@ int
 SedBase::unsetMetaId ()
 {
   mMetaId.erase();
-
-  if (mMetaId.empty())
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
+  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -1695,29 +1687,13 @@ int
 SedBase::unsetId ()
 {
   mId.erase();
-
-  if (mId.empty())
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
+  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 int SedBase::unsetName()
 {
     mName.erase();
-
-    if (mName.empty())
-    {
-        return LIBSEDML_OPERATION_SUCCESS;
-    }
-    else
-    {
-        return LIBSEDML_OPERATION_FAILED;
-    }
+    return LIBSEDML_OPERATION_SUCCESS;
 }
 
 

--- a/src/sedml/SedBase.h
+++ b/src/sedml/SedBase.h
@@ -204,16 +204,12 @@ public:
   /*
    * @return the id of this SEDML object.
    *
-   * @note The fact that the value of attribute "id" is defined on the
-   * SedBase parent class object is a convenience provided by libSEDML, and
-   * <b>does not strictly follow SEDML specifications</b>.  This libSEDML
-   * implementation of SedBase allows client applications to use more
-   * generalized code in some situations (for instance, when manipulating
-   * objects that are all known to have identifiers), but beware that not
-   * all SEDML object classes provide an "id" attribute.  LibSEDML will allow
-   * the identifier to be set, but it will not read nor write "id"
-   * attributes for objects that do not possess them according to the SEDML
-   * specification for the Level and Version in use.
+   * @note The "id" attribute was added to the SedBase class in 
+   * Level 1 version 4, and its presence here does not indicate
+   * whether the attribute was allowed on any given class in
+   * previous levels or versions.  LibSEDML will return an empty
+   * string if the attribute was not allowed on the current 
+   * level/version of the class.
    *
    */
   virtual const std::string& getId() const;
@@ -221,6 +217,13 @@ public:
 
   /**
    * @return the value of the "name" attribute (or an empty string).
+   *
+   * @note The "name" attribute was added to the SedBase class in
+   * Level 1 version 4, and its presence here does not indicate
+   * whether the attribute was allowed on any given class in
+   * previous levels or versions.  LibSEDML will return an empty
+   * string if the attribute was not allowed on the current
+   * level/version of the class.
    */
   virtual const std::string& getName() const;
 
@@ -2065,11 +2068,14 @@ protected:
 
   std::string     mMetaId;
   std::string     mId;
+  std::string     mName;
+  bool            mIdAllowedPreV4;
+  bool            mNameAllowedPreV4;
   LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode*        mNotes;
   LIBSBML_CPP_NAMESPACE_QUALIFIER XMLNode*        mAnnotation;
   SedDocument*   mSed;
   SedNamespaces* mSedNamespaces;
-  void*           mUserData;
+  void*          mUserData;
 
   unsigned int mLine;
   unsigned int mColumn;

--- a/src/sedml/SedDataDescription.cpp
+++ b/src/sedml/SedDataDescription.cpp
@@ -55,7 +55,6 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
 SedDataDescription::SedDataDescription(unsigned int level,
                                        unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mFormat ("")
   , mSource ("")
   , mDimensionDescription (NULL)
@@ -63,6 +62,8 @@ SedDataDescription::SedDataDescription(unsigned int level,
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -72,7 +73,6 @@ SedDataDescription::SedDataDescription(unsigned int level,
  */
 SedDataDescription::SedDataDescription(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mFormat ("")
   , mSource ("")
   , mDimensionDescription (NULL)
@@ -80,6 +80,8 @@ SedDataDescription::SedDataDescription(SedNamespaces *sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -88,7 +90,6 @@ SedDataDescription::SedDataDescription(SedNamespaces *sedmlns)
  */
 SedDataDescription::SedDataDescription(const SedDataDescription& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mFormat ( orig.mFormat )
   , mSource ( orig.mSource )
   , mDimensionDescription ( NULL )
@@ -112,7 +113,6 @@ SedDataDescription::operator=(const SedDataDescription& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mFormat = rhs.mFormat;
     mSource = rhs.mSource;
     mDataSources = rhs.mDataSources;
@@ -154,26 +154,6 @@ SedDataDescription::~SedDataDescription()
 
 
 /*
- * Returns the value of the "id" attribute of this SedDataDescription.
- */
-const std::string&
-SedDataDescription::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedDataDescription.
- */
-const std::string&
-SedDataDescription::getName() const
-{
-  return mName;
-}
-
-
-/*
  * Returns the value of the "format" attribute of this SedDataDescription.
  */
 const std::string&
@@ -190,28 +170,6 @@ const std::string&
 SedDataDescription::getSource() const
 {
   return mSource;
-}
-
-
-/*
- * Predicate returning @c true if this SedDataDescription's "id" attribute is
- * set.
- */
-bool
-SedDataDescription::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedDataDescription's "name" attribute is
- * set.
- */
-bool
-SedDataDescription::isSetName() const
-{
-  return (mName.empty() == false);
 }
 
 
@@ -238,28 +196,6 @@ SedDataDescription::isSetSource() const
 
 
 /*
- * Sets the value of the "id" attribute of this SedDataDescription.
- */
-int
-SedDataDescription::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedDataDescription.
- */
-int
-SedDataDescription::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
  * Sets the value of the "format" attribute of this SedDataDescription.
  */
 int
@@ -278,44 +214,6 @@ SedDataDescription::setSource(const std::string& source)
 {
   mSource = source;
   return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedDataDescription.
- */
-int
-SedDataDescription::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedDataDescription.
- */
-int
-SedDataDescription::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -848,17 +746,7 @@ SedDataDescription::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "format")
+  if (attributeName == "format")
   {
     value = getFormat();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -887,15 +775,7 @@ SedDataDescription::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "format")
+  if (attributeName == "format")
   {
     value = isSetFormat();
   }
@@ -992,15 +872,7 @@ SedDataDescription::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "format")
+  if (attributeName == "format")
   {
     return_value = setFormat(value);
   }
@@ -1243,10 +1115,6 @@ SedDataDescription::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedBase::addExpectedAttributes(attributes);
 
-  attributes.add("id");
-
-  attributes.add("name");
-
   attributes.add("format");
 
   attributes.add("source");
@@ -1308,26 +1176,7 @@ SedDataDescription::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedDataDescription>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.");
-    }
-  }
-  else
+  if (!isSetId())
   {
     if (log)
     {
@@ -1335,20 +1184,6 @@ SedDataDescription::readAttributes(
         "<SedDataDescription> element.";
       log->logError(SedmlDataDescriptionAllowedAttributes, level, version,
         message, getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedDataDescription>");
     }
   }
 
@@ -1418,16 +1253,6 @@ SedDataDescription::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   XMLOutputStream& stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetFormat() == true)
   {

--- a/src/sedml/SedDataDescription.h
+++ b/src/sedml/SedDataDescription.h
@@ -66,7 +66,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mFormat;
   std::string mSource;
   LIBNUML_CPP_NAMESPACE_QUALIFIER DimensionDescription* mDimensionDescription;
@@ -135,24 +134,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedDataDescription.
-   *
-   * @return the value of the "id" attribute of this SedDataDescription as a
-   * string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedDataDescription.
-   *
-   * @return the value of the "name" attribute of this SedDataDescription as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "format" attribute of this SedDataDescription.
    *
    * @return the value of the "format" attribute of this SedDataDescription as
@@ -168,26 +149,6 @@ public:
    * a string.
    */
   const std::string& getSource() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataDescription's "id" attribute is
-   * set.
-   *
-   * @return @c true if this SedDataDescription's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataDescription's "name" attribute
-   * is set.
-   *
-   * @return @c true if this SedDataDescription's "name" attribute has been
-   * set, otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -208,36 +169,6 @@ public:
    * set, otherwise @c false is returned.
    */
   bool isSetSource() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedDataDescription.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedDataDescription.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
 
 
   /**
@@ -266,26 +197,6 @@ public:
    * equivalent to calling unsetSource().
    */
   int setSource(const std::string& source);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedDataDescription.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedDataDescription.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedDataGenerator.cpp
+++ b/src/sedml/SedDataGenerator.cpp
@@ -56,13 +56,14 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedDataGenerator::SedDataGenerator(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mVariables (level, version)
   , mParameters (level, version)
   , mMath (NULL)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -72,13 +73,14 @@ SedDataGenerator::SedDataGenerator(unsigned int level, unsigned int version)
  */
 SedDataGenerator::SedDataGenerator(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mVariables (sedmlns)
   , mParameters (sedmlns)
   , mMath (NULL)
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -87,7 +89,6 @@ SedDataGenerator::SedDataGenerator(SedNamespaces *sedmlns)
  */
 SedDataGenerator::SedDataGenerator(const SedDataGenerator& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mVariables ( orig.mVariables )
   , mParameters ( orig.mParameters )
   , mMath ( NULL )
@@ -110,7 +111,6 @@ SedDataGenerator::operator=(const SedDataGenerator& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mVariables = rhs.mVariables;
     mParameters = rhs.mParameters;
     delete mMath;
@@ -147,108 +147,6 @@ SedDataGenerator::~SedDataGenerator()
 {
   delete mMath;
   mMath = NULL;
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedDataGenerator.
- */
-const std::string&
-SedDataGenerator::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedDataGenerator.
- */
-const std::string&
-SedDataGenerator::getName() const
-{
-  return mName;
-}
-
-
-/*
- * Predicate returning @c true if this SedDataGenerator's "id" attribute is
- * set.
- */
-bool
-SedDataGenerator::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedDataGenerator's "name" attribute is
- * set.
- */
-bool
-SedDataGenerator::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedDataGenerator.
- */
-int
-SedDataGenerator::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedDataGenerator.
- */
-int
-SedDataGenerator::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedDataGenerator.
- */
-int
-SedDataGenerator::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedDataGenerator.
- */
-int
-SedDataGenerator::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -934,17 +832,6 @@ SedDataGenerator::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-
   return return_value;
 }
 
@@ -962,15 +849,6 @@ bool
 SedDataGenerator::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
 
   return value;
 }
@@ -1059,15 +937,6 @@ SedDataGenerator::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-
   return return_value;
 }
 
@@ -1084,15 +953,6 @@ int
 SedDataGenerator::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
 
   return value;
 }
@@ -1323,10 +1183,6 @@ SedDataGenerator::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 }
 
 /** @endcond */
@@ -1385,26 +1241,7 @@ SedDataGenerator::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedDataGenerator>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.");
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1415,19 +1252,6 @@ SedDataGenerator::readAttributes(
     }
   }
 
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedDataGenerator>");
-    }
-  }
 }
 
 /** @endcond */
@@ -1477,16 +1301,6 @@ SedDataGenerator::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   XMLOutputStream& stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 }
 
 /** @endcond */

--- a/src/sedml/SedDataGenerator.h
+++ b/src/sedml/SedDataGenerator.h
@@ -66,7 +66,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   SedListOfVariables mVariables;
   SedListOfParameters mParameters;
   LIBSBML_CPP_NAMESPACE_QUALIFIER ASTNode* mMath;
@@ -131,94 +130,6 @@ public:
    * Destructor for SedDataGenerator.
    */
   virtual ~SedDataGenerator();
-
-
-  /**
-   * Returns the value of the "id" attribute of this SedDataGenerator.
-   *
-   * @return the value of the "id" attribute of this SedDataGenerator as a
-   * string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedDataGenerator.
-   *
-   * @return the value of the "name" attribute of this SedDataGenerator as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataGenerator's "id" attribute is
-   * set.
-   *
-   * @return @c true if this SedDataGenerator's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataGenerator's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedDataGenerator's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedDataGenerator.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedDataGenerator.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedDataGenerator.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedDataGenerator.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedDataSet.cpp
+++ b/src/sedml/SedDataSet.cpp
@@ -58,6 +58,7 @@ SedDataSet::SedDataSet(unsigned int level, unsigned int version)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   mNameAllowedPreV4 = true;
+  mIdAllowedPreV4 = true;
 }
 
 
@@ -71,6 +72,7 @@ SedDataSet::SedDataSet(SedNamespaces *sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   mNameAllowedPreV4 = true;
+  mIdAllowedPreV4 = true;
 }
 
 

--- a/src/sedml/SedDataSet.cpp
+++ b/src/sedml/SedDataSet.cpp
@@ -54,10 +54,10 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
 SedDataSet::SedDataSet(unsigned int level, unsigned int version)
   : SedBase(level, version)
   , mLabel ("")
-  , mName ("")
   , mDataReference ("")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -67,10 +67,10 @@ SedDataSet::SedDataSet(unsigned int level, unsigned int version)
 SedDataSet::SedDataSet(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
   , mLabel ("")
-  , mName ("")
   , mDataReference ("")
 {
   setElementNamespace(sedmlns->getURI());
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -80,7 +80,6 @@ SedDataSet::SedDataSet(SedNamespaces *sedmlns)
 SedDataSet::SedDataSet(const SedDataSet& orig)
   : SedBase( orig )
   , mLabel ( orig.mLabel )
-  , mName ( orig.mName )
   , mDataReference ( orig.mDataReference )
 {
 }
@@ -96,7 +95,6 @@ SedDataSet::operator=(const SedDataSet& rhs)
   {
     SedBase::operator=(rhs);
     mLabel = rhs.mLabel;
-    mName = rhs.mName;
     mDataReference = rhs.mDataReference;
   }
 
@@ -123,32 +121,12 @@ SedDataSet::~SedDataSet()
 
 
 /*
- * Returns the value of the "id" attribute of this SedDataSet.
- */
-const std::string&
-SedDataSet::getId() const
-{
-  return mId;
-}
-
-
-/*
  * Returns the value of the "label" attribute of this SedDataSet.
  */
 const std::string&
 SedDataSet::getLabel() const
 {
   return mLabel;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedDataSet.
- */
-const std::string&
-SedDataSet::getName() const
-{
-  return mName;
 }
 
 
@@ -163,32 +141,12 @@ SedDataSet::getDataReference() const
 
 
 /*
- * Predicate returning @c true if this SedDataSet's "id" attribute is set.
- */
-bool
-SedDataSet::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedDataSet's "label" attribute is set.
  */
 bool
 SedDataSet::isSetLabel() const
 {
   return (mLabel.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedDataSet's "name" attribute is set.
- */
-bool
-SedDataSet::isSetName() const
-{
-  return (mName.empty() == false);
 }
 
 
@@ -204,34 +162,12 @@ SedDataSet::isSetDataReference() const
 
 
 /*
- * Sets the value of the "id" attribute of this SedDataSet.
- */
-int
-SedDataSet::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
  * Sets the value of the "label" attribute of this SedDataSet.
  */
 int
 SedDataSet::setLabel(const std::string& label)
 {
   mLabel = label;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedDataSet.
- */
-int
-SedDataSet::setName(const std::string& name)
-{
-  mName = name;
   return LIBSEDML_OPERATION_SUCCESS;
 }
 
@@ -255,25 +191,6 @@ SedDataSet::setDataReference(const std::string& dataReference)
 
 
 /*
- * Unsets the value of the "id" attribute of this SedDataSet.
- */
-int
-SedDataSet::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
  * Unsets the value of the "label" attribute of this SedDataSet.
  */
 int
@@ -282,25 +199,6 @@ SedDataSet::unsetLabel()
   mLabel.erase();
 
   if (mLabel.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedDataSet.
- */
-int
-SedDataSet::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -525,19 +423,9 @@ SedDataSet::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "label")
+  if (attributeName == "label")
   {
     value = getLabel();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
     return_value = LIBSEDML_OPERATION_SUCCESS;
   }
   else if (attributeName == "dataReference")
@@ -564,17 +452,9 @@ SedDataSet::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "label")
+  if (attributeName == "label")
   {
     value = isSetLabel();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
   }
   else if (attributeName == "dataReference")
   {
@@ -667,17 +547,9 @@ SedDataSet::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "label")
+  if (attributeName == "label")
   {
     return_value = setLabel(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
   }
   else if (attributeName == "dataReference")
   {
@@ -701,17 +573,9 @@ SedDataSet::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "label")
+  if (attributeName == "label")
   {
     value = unsetLabel();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
   }
   else if (attributeName == "dataReference")
   {
@@ -736,11 +600,7 @@ SedDataSet::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedBase::addExpectedAttributes(attributes);
 
-  attributes.add("id");
-
   attributes.add("label");
-
-  attributes.add("name");
 
   attributes.add("dataReference");
 }
@@ -801,26 +661,7 @@ SedDataSet::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedDataSet>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -852,20 +693,6 @@ SedDataSet::readAttributes(
         "<SedDataSet> element.";
       log->logError(SedmlDataSetAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedDataSet>");
     }
   }
 
@@ -923,19 +750,9 @@ SedDataSet::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
 {
   SedBase::writeAttributes(stream);
 
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
   if (isSetLabel() == true)
   {
     stream.writeAttribute("label", getPrefix(), mLabel);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
   }
 
   if (isSetDataReference() == true)

--- a/src/sedml/SedDataSet.h
+++ b/src/sedml/SedDataSet.h
@@ -64,7 +64,6 @@ protected:
   /** @cond doxygenLibSEDMLInternal */
 
   std::string mLabel;
-  std::string mName;
   std::string mDataReference;
 
   /** @endcond */
@@ -129,27 +128,11 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedDataSet.
-   *
-   * @return the value of the "id" attribute of this SedDataSet as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
    * Returns the value of the "label" attribute of this SedDataSet.
    *
    * @return the value of the "label" attribute of this SedDataSet as a string.
    */
   const std::string& getLabel() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedDataSet.
-   *
-   * @return the value of the "name" attribute of this SedDataSet as a string.
-   */
-  virtual const std::string& getName() const;
 
 
   /**
@@ -162,30 +145,12 @@ public:
 
 
   /**
-   * Predicate returning @c true if this SedDataSet's "id" attribute is set.
-   *
-   * @return @c true if this SedDataSet's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
    * Predicate returning @c true if this SedDataSet's "label" attribute is set.
    *
    * @return @c true if this SedDataSet's "label" attribute has been set,
    * otherwise @c false is returned.
    */
   bool isSetLabel() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataSet's "name" attribute is set.
-   *
-   * @return @c true if this SedDataSet's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -196,22 +161,6 @@ public:
    * set, otherwise @c false is returned.
    */
   bool isSetDataReference() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedDataSet.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
 
 
   /**
@@ -229,20 +178,6 @@ public:
 
 
   /**
-   * Sets the value of the "name" attribute of this SedDataSet.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
    * Sets the value of the "dataReference" attribute of this SedDataSet.
    *
    * @param dataReference std::string& value of the "dataReference" attribute
@@ -257,16 +192,6 @@ public:
 
 
   /**
-   * Unsets the value of the "id" attribute of this SedDataSet.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
    * Unsets the value of the "label" attribute of this SedDataSet.
    *
    * @copydetails doc_returns_success_code
@@ -274,16 +199,6 @@ public:
    * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
    */
   int unsetLabel();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedDataSet.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedDataSource.cpp
+++ b/src/sedml/SedDataSource.cpp
@@ -54,12 +54,13 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedDataSource::SedDataSource(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mIndexSet ("")
   , mSlices (level, version)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -68,12 +69,13 @@ SedDataSource::SedDataSource(unsigned int level, unsigned int version)
  */
 SedDataSource::SedDataSource(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mIndexSet ("")
   , mSlices (sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -82,7 +84,6 @@ SedDataSource::SedDataSource(SedNamespaces *sedmlns)
  */
 SedDataSource::SedDataSource(const SedDataSource& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mIndexSet ( orig.mIndexSet )
   , mSlices ( orig.mSlices )
 {
@@ -99,7 +100,6 @@ SedDataSource::operator=(const SedDataSource& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mIndexSet = rhs.mIndexSet;
     mSlices = rhs.mSlices;
     connectToChild();
@@ -128,52 +128,12 @@ SedDataSource::~SedDataSource()
 
 
 /*
- * Returns the value of the "id" attribute of this SedDataSource.
- */
-const std::string&
-SedDataSource::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedDataSource.
- */
-const std::string&
-SedDataSource::getName() const
-{
-  return mName;
-}
-
-
-/*
  * Returns the value of the "indexSet" attribute of this SedDataSource.
  */
 const std::string&
 SedDataSource::getIndexSet() const
 {
   return mIndexSet;
-}
-
-
-/*
- * Predicate returning @c true if this SedDataSource's "id" attribute is set.
- */
-bool
-SedDataSource::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedDataSource's "name" attribute is set.
- */
-bool
-SedDataSource::isSetName() const
-{
-  return (mName.empty() == false);
 }
 
 
@@ -185,28 +145,6 @@ bool
 SedDataSource::isSetIndexSet() const
 {
   return (mIndexSet.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedDataSource.
- */
-int
-SedDataSource::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedDataSource.
- */
-int
-SedDataSource::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -224,44 +162,6 @@ SedDataSource::setIndexSet(const std::string& indexSet)
   {
     mIndexSet = indexSet;
     return LIBSEDML_OPERATION_SUCCESS;
-  }
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedDataSource.
- */
-int
-SedDataSource::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedDataSource.
- */
-int
-SedDataSource::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
   }
 }
 
@@ -660,17 +560,7 @@ SedDataSource::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "indexSet")
+  if (attributeName == "indexSet")
   {
     value = getIndexSet();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -694,15 +584,7 @@ SedDataSource::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "indexSet")
+  if (attributeName == "indexSet")
   {
     value = isSetIndexSet();
   }
@@ -794,15 +676,7 @@ SedDataSource::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "indexSet")
+  if (attributeName == "indexSet")
   {
     return_value = setIndexSet(value);
   }
@@ -824,15 +698,7 @@ SedDataSource::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "indexSet")
+  if (attributeName == "indexSet")
   {
     value = unsetIndexSet();
   }
@@ -1028,10 +894,6 @@ SedDataSource::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedBase::addExpectedAttributes(attributes);
 
-  attributes.add("id");
-
-  attributes.add("name");
-
   attributes.add("indexSet");
 }
 
@@ -1091,26 +953,7 @@ SedDataSource::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedDataSource>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1118,20 +961,6 @@ SedDataSource::readAttributes(
         "<SedDataSource> element.";
       log->logError(SedmlDataSourceAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedDataSource>");
     }
   }
 
@@ -1177,16 +1006,6 @@ SedDataSource::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetIndexSet() == true)
   {

--- a/src/sedml/SedDataSource.h
+++ b/src/sedml/SedDataSource.h
@@ -64,7 +64,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mIndexSet;
   SedListOfSlices mSlices;
 
@@ -131,48 +130,12 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedDataSource.
-   *
-   * @return the value of the "id" attribute of this SedDataSource as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedDataSource.
-   *
-   * @return the value of the "name" attribute of this SedDataSource as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "indexSet" attribute of this SedDataSource.
    *
    * @return the value of the "indexSet" attribute of this SedDataSource as a
    * string.
    */
   const std::string& getIndexSet() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataSource's "id" attribute is set.
-   *
-   * @return @c true if this SedDataSource's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedDataSource's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedDataSource's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -186,36 +149,6 @@ public:
 
 
   /**
-   * Sets the value of the "id" attribute of this SedDataSource.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedDataSource.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
    * Sets the value of the "indexSet" attribute of this SedDataSource.
    *
    * @param indexSet std::string& value of the "indexSet" attribute to be set.
@@ -226,26 +159,6 @@ public:
    * OperationReturnValues_t}
    */
   int setIndexSet(const std::string& indexSet);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedDataSource.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedDataSource.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedFitExperiment.cpp
+++ b/src/sedml/SedFitExperiment.cpp
@@ -145,16 +145,6 @@ SedFitExperiment::~SedFitExperiment()
 
 
 /*
- * Returns the value of the "id" attribute of this SedFitExperiment.
- */
-const std::string&
-SedFitExperiment::getId() const
-{
-  return mId;
-}
-
-
-/*
  * Returns the value of the "type" attribute of this SedFitExperiment.
  */
 ExperimentType_t
@@ -176,17 +166,6 @@ SedFitExperiment::getTypeAsString() const
 
 
 /*
- * Predicate returning @c true if this SedFitExperiment's "id" attribute is
- * set.
- */
-bool
-SedFitExperiment::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedFitExperiment's "type" attribute is
  * set.
  */
@@ -194,17 +173,6 @@ bool
 SedFitExperiment::isSetType() const
 {
   return (mType != SEDML_EXPERIMENTTYPE_INVALID);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedFitExperiment.
- */
-int
-SedFitExperiment::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -241,25 +209,6 @@ SedFitExperiment::setType(const std::string& type)
   }
 
   return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedFitExperiment.
- */
-int
-SedFitExperiment::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -1228,26 +1177,6 @@ SedFitExperiment::readAttributes(
   }
 
   // 
-  // id SId (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedFitExperiment>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-
-  // 
   // type enum (use = "optional" )
   // 
 
@@ -1296,11 +1225,6 @@ SedFitExperiment::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   XMLOutputStream& stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
 
   if (isSetType() == true)
   {

--- a/src/sedml/SedFitExperiment.h
+++ b/src/sedml/SedFitExperiment.h
@@ -159,15 +159,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedFitExperiment.
-   *
-   * @return the value of the "id" attribute of this SedFitExperiment as a
-   * string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
    * Returns the value of the "type" attribute of this SedFitExperiment.
    *
    * @return the value of the "type" attribute of this SedFitExperiment as a
@@ -200,16 +191,6 @@ public:
 
 
   /**
-   * Predicate returning @c true if this SedFitExperiment's "id" attribute is
-   * set.
-   *
-   * @return @c true if this SedFitExperiment's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
    * Predicate returning @c true if this SedFitExperiment's "type" attribute is
    * set.
    *
@@ -219,22 +200,6 @@ public:
    * @copydetails doc_sedfitexperiment_type
    */
   bool isSetType() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedFitExperiment.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
 
 
   /**
@@ -266,16 +231,6 @@ public:
    * @copydetails doc_sedfitexperiment_type
    */
   int setType(const std::string& type);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedFitExperiment.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
 
 
   /**

--- a/src/sedml/SedModel.cpp
+++ b/src/sedml/SedModel.cpp
@@ -59,13 +59,14 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedModel::SedModel(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mLanguage ("")
   , mSource ("")
   , mChanges (level, version)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -74,13 +75,14 @@ SedModel::SedModel(unsigned int level, unsigned int version)
  */
 SedModel::SedModel(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mLanguage ("")
   , mSource ("")
   , mChanges (sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -89,7 +91,6 @@ SedModel::SedModel(SedNamespaces *sedmlns)
  */
 SedModel::SedModel(const SedModel& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mLanguage ( orig.mLanguage )
   , mSource ( orig.mSource )
   , mChanges ( orig.mChanges )
@@ -107,7 +108,6 @@ SedModel::operator=(const SedModel& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mLanguage = rhs.mLanguage;
     mSource = rhs.mSource;
     mChanges = rhs.mChanges;
@@ -137,26 +137,6 @@ SedModel::~SedModel()
 
 
 /*
- * Returns the value of the "id" attribute of this SedModel.
- */
-const std::string&
-SedModel::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedModel.
- */
-const std::string&
-SedModel::getName() const
-{
-  return mName;
-}
-
-
-/*
  * Returns the value of the "language" attribute of this SedModel.
  */
 const std::string&
@@ -173,26 +153,6 @@ const std::string&
 SedModel::getSource() const
 {
   return mSource;
-}
-
-
-/*
- * Predicate returning @c true if this SedModel's "id" attribute is set.
- */
-bool
-SedModel::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedModel's "name" attribute is set.
- */
-bool
-SedModel::isSetName() const
-{
-  return (mName.empty() == false);
 }
 
 
@@ -217,28 +177,6 @@ SedModel::isSetSource() const
 
 
 /*
- * Sets the value of the "id" attribute of this SedModel.
- */
-int
-SedModel::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedModel.
- */
-int
-SedModel::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
  * Sets the value of the "language" attribute of this SedModel.
  */
 int
@@ -257,44 +195,6 @@ SedModel::setSource(const std::string& source)
 {
   mSource = source;
   return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedModel.
- */
-int
-SedModel::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedModel.
- */
-int
-SedModel::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -760,17 +660,7 @@ SedModel::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "language")
+  if (attributeName == "language")
   {
     value = getLanguage();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -799,15 +689,7 @@ SedModel::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "language")
+  if (attributeName == "language")
   {
     value = isSetLanguage();
   }
@@ -902,15 +784,7 @@ SedModel::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "language")
+  if (attributeName == "language")
   {
     return_value = setLanguage(value);
   }
@@ -936,15 +810,7 @@ SedModel::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "language")
+  if (attributeName == "language")
   {
     value = unsetLanguage();
   }
@@ -1219,10 +1085,6 @@ SedModel::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedBase::addExpectedAttributes(attributes);
 
-  attributes.add("id");
-
-  attributes.add("name");
-
   attributes.add("language");
 
   attributes.add("source");
@@ -1284,26 +1146,7 @@ SedModel::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedModel>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1311,20 +1154,6 @@ SedModel::readAttributes(
         "<SedModel> element.";
       log->logError(SedmlModelAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedModel>");
     }
   }
 
@@ -1381,16 +1210,6 @@ SedModel::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetLanguage() == true)
   {

--- a/src/sedml/SedModel.h
+++ b/src/sedml/SedModel.h
@@ -64,7 +64,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mLanguage;
   std::string mSource;
   SedListOfChanges mChanges;
@@ -129,22 +128,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedModel.
-   *
-   * @return the value of the "id" attribute of this SedModel as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedModel.
-   *
-   * @return the value of the "name" attribute of this SedModel as a string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "language" attribute of this SedModel.
    *
    * @return the value of the "language" attribute of this SedModel as a
@@ -159,24 +142,6 @@ public:
    * @return the value of the "source" attribute of this SedModel as a string.
    */
   const std::string& getSource() const;
-
-
-  /**
-   * Predicate returning @c true if this SedModel's "id" attribute is set.
-   *
-   * @return @c true if this SedModel's "id" attribute has been set, otherwise
-   * @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedModel's "name" attribute is set.
-   *
-   * @return @c true if this SedModel's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -196,36 +161,6 @@ public:
    * otherwise @c false is returned.
    */
   bool isSetSource() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedModel.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedModel.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
 
 
   /**
@@ -254,26 +189,6 @@ public:
    * equivalent to calling unsetSource().
    */
   int setSource(const std::string& source);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedModel.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedModel.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedOutput.cpp
+++ b/src/sedml/SedOutput.cpp
@@ -59,10 +59,11 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedOutput::SedOutput(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mElementName("output")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -71,10 +72,11 @@ SedOutput::SedOutput(unsigned int level, unsigned int version)
  */
 SedOutput::SedOutput(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mElementName("output")
 {
   setElementNamespace(sedmlns->getURI());
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -83,7 +85,6 @@ SedOutput::SedOutput(SedNamespaces *sedmlns)
  */
 SedOutput::SedOutput(const SedOutput& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mElementName ( orig.mElementName )
 {
 }
@@ -98,7 +99,6 @@ SedOutput::operator=(const SedOutput& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mElementName = rhs.mElementName;
   }
 
@@ -121,106 +121,6 @@ SedOutput::clone() const
  */
 SedOutput::~SedOutput()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedOutput.
- */
-const std::string&
-SedOutput::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedOutput.
- */
-const std::string&
-SedOutput::getName() const
-{
-  return mName;
-}
-
-
-/*
- * Predicate returning @c true if this SedOutput's "id" attribute is set.
- */
-bool
-SedOutput::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedOutput's "name" attribute is set.
- */
-bool
-SedOutput::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedOutput.
- */
-int
-SedOutput::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedOutput.
- */
-int
-SedOutput::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedOutput.
- */
-int
-SedOutput::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedOutput.
- */
-int
-SedOutput::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -459,17 +359,6 @@ SedOutput::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-
   return return_value;
 }
 
@@ -487,15 +376,6 @@ bool
 SedOutput::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
 
   return value;
 }
@@ -583,15 +463,6 @@ SedOutput::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-
   return return_value;
 }
 
@@ -608,15 +479,6 @@ int
 SedOutput::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
 
   return value;
 }
@@ -635,10 +497,6 @@ SedOutput::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 }
 
 /** @endcond */
@@ -696,40 +554,6 @@ SedOutput::readAttributes(
       }
     }
   }
-
-  // 
-  // id SId (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedOutput>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedOutput>");
-    }
-  }
 }
 
 /** @endcond */
@@ -746,16 +570,6 @@ SedOutput::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 }
 
 /** @endcond */

--- a/src/sedml/SedOutput.h
+++ b/src/sedml/SedOutput.h
@@ -69,7 +69,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mElementName;
 
   /** @endcond */
@@ -130,90 +129,6 @@ public:
    * Destructor for SedOutput.
    */
   virtual ~SedOutput();
-
-
-  /**
-   * Returns the value of the "id" attribute of this SedOutput.
-   *
-   * @return the value of the "id" attribute of this SedOutput as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedOutput.
-   *
-   * @return the value of the "name" attribute of this SedOutput as a string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
-   * Predicate returning @c true if this SedOutput's "id" attribute is set.
-   *
-   * @return @c true if this SedOutput's "id" attribute has been set, otherwise
-   * @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedOutput's "name" attribute is set.
-   *
-   * @return @c true if this SedOutput's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedOutput.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedOutput.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedOutput.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedOutput.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedParameter.cpp
+++ b/src/sedml/SedParameter.cpp
@@ -54,11 +54,12 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedParameter::SedParameter(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mValue (util_NaN())
   , mIsSetValue (false)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -67,11 +68,12 @@ SedParameter::SedParameter(unsigned int level, unsigned int version)
  */
 SedParameter::SedParameter(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mValue (util_NaN())
   , mIsSetValue (false)
 {
   setElementNamespace(sedmlns->getURI());
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -80,7 +82,6 @@ SedParameter::SedParameter(SedNamespaces *sedmlns)
  */
 SedParameter::SedParameter(const SedParameter& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mValue ( orig.mValue )
   , mIsSetValue ( orig.mIsSetValue )
 {
@@ -96,7 +97,6 @@ SedParameter::operator=(const SedParameter& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mValue = rhs.mValue;
     mIsSetValue = rhs.mIsSetValue;
   }
@@ -124,52 +124,12 @@ SedParameter::~SedParameter()
 
 
 /*
- * Returns the value of the "id" attribute of this SedParameter.
- */
-const std::string&
-SedParameter::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedParameter.
- */
-const std::string&
-SedParameter::getName() const
-{
-  return mName;
-}
-
-
-/*
  * Returns the value of the "value" attribute of this SedParameter.
  */
 double
 SedParameter::getValue() const
 {
   return mValue;
-}
-
-
-/*
- * Predicate returning @c true if this SedParameter's "id" attribute is set.
- */
-bool
-SedParameter::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedParameter's "name" attribute is set.
- */
-bool
-SedParameter::isSetName() const
-{
-  return (mName.empty() == false);
 }
 
 
@@ -184,28 +144,6 @@ SedParameter::isSetValue() const
 
 
 /*
- * Sets the value of the "id" attribute of this SedParameter.
- */
-int
-SedParameter::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedParameter.
- */
-int
-SedParameter::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
  * Sets the value of the "value" attribute of this SedParameter.
  */
 int
@@ -214,44 +152,6 @@ SedParameter::setValue(double value)
   mValue = value;
   mIsSetValue = true;
   return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedParameter.
- */
-int
-SedParameter::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedParameter.
- */
-int
-SedParameter::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -464,17 +364,6 @@ SedParameter::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-
   return return_value;
 }
 
@@ -493,15 +382,7 @@ SedParameter::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "value")
+  if (attributeName == "value")
   {
     value = isSetValue();
   }
@@ -598,15 +479,6 @@ SedParameter::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-
   return return_value;
 }
 
@@ -624,15 +496,7 @@ SedParameter::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "value")
+  if (attributeName == "value")
   {
     value = unsetValue();
   }
@@ -654,10 +518,6 @@ SedParameter::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 
   attributes.add("value");
 }
@@ -718,26 +578,7 @@ SedParameter::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedParameter>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -745,20 +586,6 @@ SedParameter::readAttributes(
         "<SedParameter> element.";
       log->logError(SedmlParameterAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedParameter>");
     }
   }
 
@@ -804,16 +631,6 @@ SedParameter::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetValue() == true)
   {

--- a/src/sedml/SedParameter.h
+++ b/src/sedml/SedParameter.h
@@ -63,7 +63,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   double mValue;
   bool mIsSetValue;
 
@@ -130,48 +129,12 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedParameter.
-   *
-   * @return the value of the "id" attribute of this SedParameter as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedParameter.
-   *
-   * @return the value of the "name" attribute of this SedParameter as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "value" attribute of this SedParameter.
    *
    * @return the value of the "value" attribute of this SedParameter as a
    * double.
    */
   double getValue() const;
-
-
-  /**
-   * Predicate returning @c true if this SedParameter's "id" attribute is set.
-   *
-   * @return @c true if this SedParameter's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedParameter's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedParameter's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -185,36 +148,6 @@ public:
 
 
   /**
-   * Sets the value of the "id" attribute of this SedParameter.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedParameter.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
    * Sets the value of the "value" attribute of this SedParameter.
    *
    * @param value double value of the "value" attribute to be set.
@@ -225,26 +158,6 @@ public:
    * OperationReturnValues_t}
    */
   int setValue(double value);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedParameter.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedParameter.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedRange.cpp
+++ b/src/sedml/SedRange.cpp
@@ -61,6 +61,7 @@ SedRange::SedRange(unsigned int level, unsigned int version)
   , mElementName("range")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mIdAllowedPreV4 = true;
 }
 
 
@@ -72,6 +73,7 @@ SedRange::SedRange(SedNamespaces *sedmlns)
   , mElementName("range")
 {
   setElementNamespace(sedmlns->getURI());
+  mIdAllowedPreV4 = true;
 }
 
 
@@ -116,56 +118,6 @@ SedRange::clone() const
  */
 SedRange::~SedRange()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedRange.
- */
-const std::string&
-SedRange::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Predicate returning @c true if this SedRange's "id" attribute is set.
- */
-bool
-SedRange::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedRange.
- */
-int
-SedRange::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedRange.
- */
-int
-SedRange::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -617,26 +569,7 @@ SedRange::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedRange>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -662,11 +595,6 @@ SedRange::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
 }
 
 /** @endcond */

--- a/src/sedml/SedRange.h
+++ b/src/sedml/SedRange.h
@@ -130,49 +130,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedRange.
-   *
-   * @return the value of the "id" attribute of this SedRange as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedRange's "id" attribute is set.
-   *
-   * @return @c true if this SedRange's "id" attribute has been set, otherwise
-   * @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedRange.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedRange.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
    * Predicate returning @c true if this abstract "SedRange" is of type
    * SedUniformRange
    *

--- a/src/sedml/SedSimulation.cpp
+++ b/src/sedml/SedSimulation.cpp
@@ -58,12 +58,13 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedSimulation::SedSimulation(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mAlgorithm (NULL)
   , mElementName("simulation")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -72,12 +73,13 @@ SedSimulation::SedSimulation(unsigned int level, unsigned int version)
  */
 SedSimulation::SedSimulation(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mAlgorithm (NULL)
   , mElementName("simulation")
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -86,7 +88,6 @@ SedSimulation::SedSimulation(SedNamespaces *sedmlns)
  */
 SedSimulation::SedSimulation(const SedSimulation& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mAlgorithm ( NULL )
   , mElementName ( orig.mElementName )
 {
@@ -108,7 +109,6 @@ SedSimulation::operator=(const SedSimulation& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mElementName = rhs.mElementName;
     delete mAlgorithm;
     if (rhs.mAlgorithm != NULL)
@@ -144,106 +144,6 @@ SedSimulation::~SedSimulation()
 {
   delete mAlgorithm;
   mAlgorithm = NULL;
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedSimulation.
- */
-const std::string&
-SedSimulation::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedSimulation.
- */
-const std::string&
-SedSimulation::getName() const
-{
-  return mName;
-}
-
-
-/*
- * Predicate returning @c true if this SedSimulation's "id" attribute is set.
- */
-bool
-SedSimulation::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedSimulation's "name" attribute is set.
- */
-bool
-SedSimulation::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedSimulation.
- */
-int
-SedSimulation::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedSimulation.
- */
-int
-SedSimulation::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedSimulation.
- */
-int
-SedSimulation::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedSimulation.
- */
-int
-SedSimulation::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -609,17 +509,6 @@ SedSimulation::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-
   return return_value;
 }
 
@@ -637,15 +526,6 @@ bool
 SedSimulation::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
 
   return value;
 }
@@ -734,15 +614,6 @@ SedSimulation::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-
   return return_value;
 }
 
@@ -759,15 +630,6 @@ int
 SedSimulation::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
-
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
 
   return value;
 }
@@ -967,10 +829,6 @@ SedSimulation::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 }
 
 /** @endcond */
@@ -1029,26 +887,7 @@ SedSimulation::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedSimulation>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1056,20 +895,6 @@ SedSimulation::readAttributes(
         "<SedSimulation> element.";
       log->logError(SedmlSimulationAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedSimulation>");
     }
   }
 }
@@ -1088,16 +913,6 @@ SedSimulation::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 }
 
 /** @endcond */

--- a/src/sedml/SedSimulation.h
+++ b/src/sedml/SedSimulation.h
@@ -68,7 +68,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   SedAlgorithm* mAlgorithm;
   std::string mElementName;
 
@@ -132,92 +131,6 @@ public:
    * Destructor for SedSimulation.
    */
   virtual ~SedSimulation();
-
-
-  /**
-   * Returns the value of the "id" attribute of this SedSimulation.
-   *
-   * @return the value of the "id" attribute of this SedSimulation as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedSimulation.
-   *
-   * @return the value of the "name" attribute of this SedSimulation as a
-   * string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
-   * Predicate returning @c true if this SedSimulation's "id" attribute is set.
-   *
-   * @return @c true if this SedSimulation's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedSimulation's "name" attribute is
-   * set.
-   *
-   * @return @c true if this SedSimulation's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedSimulation.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedSimulation.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedSimulation.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedSimulation.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedStyle.cpp
+++ b/src/sedml/SedStyle.cpp
@@ -179,16 +179,6 @@ SedStyle::~SedStyle()
 
 
 /*
- * Returns the value of the "id" attribute of this SedStyle.
- */
-const std::string&
-SedStyle::getId() const
-{
-  return mId;
-}
-
-
-/*
  * Returns the value of the "baseStyle" attribute of this SedStyle.
  */
 const std::string&
@@ -199,33 +189,12 @@ SedStyle::getBaseStyle() const
 
 
 /*
- * Predicate returning @c true if this SedStyle's "id" attribute is set.
- */
-bool
-SedStyle::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedStyle's "baseStyle" attribute is set.
  */
 bool
 SedStyle::isSetBaseStyle() const
 {
   return (mBaseStyle.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedStyle.
- */
-int
-SedStyle::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -243,25 +212,6 @@ SedStyle::setBaseStyle(const std::string& baseStyle)
   {
     mBaseStyle = baseStyle;
     return LIBSEDML_OPERATION_SUCCESS;
-  }
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedStyle.
- */
-int
-SedStyle::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
   }
 }
 
@@ -1328,26 +1278,7 @@ SedStyle::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedStyle>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1400,11 +1331,6 @@ SedStyle::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
 
   if (isSetBaseStyle() == true)
   {

--- a/src/sedml/SedStyle.h
+++ b/src/sedml/SedStyle.h
@@ -131,29 +131,12 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedStyle.
-   *
-   * @return the value of the "id" attribute of this SedStyle as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
    * Returns the value of the "baseStyle" attribute of this SedStyle.
    *
    * @return the value of the "baseStyle" attribute of this SedStyle as a
    * string.
    */
   const std::string& getBaseStyle() const;
-
-
-  /**
-   * Predicate returning @c true if this SedStyle's "id" attribute is set.
-   *
-   * @return @c true if this SedStyle's "id" attribute has been set, otherwise
-   * @c false is returned.
-   */
-  virtual bool isSetId() const;
 
 
   /**
@@ -164,22 +147,6 @@ public:
    * otherwise @c false is returned.
    */
   bool isSetBaseStyle() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedStyle.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
 
 
   /**
@@ -194,16 +161,6 @@ public:
    * OperationReturnValues_t}
    */
   int setBaseStyle(const std::string& baseStyle);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedStyle.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
 
 
   /**

--- a/src/sedml/SedSurface.cpp
+++ b/src/sedml/SedSurface.cpp
@@ -68,7 +68,7 @@ SedSurface::SedSurface(unsigned int level, unsigned int version)
   , mIsSetOrder (false)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
-  mNameAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;  mIdAllowedPreV4 = true;
 }
 
 
@@ -93,6 +93,7 @@ SedSurface::SedSurface(SedNamespaces *sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   mNameAllowedPreV4 = true;
+  mIdAllowedPreV4 = true;
 }
 
 

--- a/src/sedml/SedSurface.cpp
+++ b/src/sedml/SedSurface.cpp
@@ -53,7 +53,6 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedSurface::SedSurface(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mXDataReference ("")
   , mYDataReference ("")
   , mZDataReference ("")
@@ -69,6 +68,7 @@ SedSurface::SedSurface(unsigned int level, unsigned int version)
   , mIsSetOrder (false)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -77,7 +77,6 @@ SedSurface::SedSurface(unsigned int level, unsigned int version)
  */
 SedSurface::SedSurface(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mXDataReference ("")
   , mYDataReference ("")
   , mZDataReference ("")
@@ -93,6 +92,7 @@ SedSurface::SedSurface(SedNamespaces *sedmlns)
   , mIsSetOrder (false)
 {
   setElementNamespace(sedmlns->getURI());
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -101,7 +101,6 @@ SedSurface::SedSurface(SedNamespaces *sedmlns)
  */
 SedSurface::SedSurface(const SedSurface& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mXDataReference ( orig.mXDataReference )
   , mYDataReference ( orig.mYDataReference )
   , mZDataReference ( orig.mZDataReference )
@@ -128,7 +127,6 @@ SedSurface::operator=(const SedSurface& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mXDataReference = rhs.mXDataReference;
     mYDataReference = rhs.mYDataReference;
     mZDataReference = rhs.mZDataReference;
@@ -163,26 +161,6 @@ SedSurface::clone() const
  */
 SedSurface::~SedSurface()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedSurface.
- */
-const std::string&
-SedSurface::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedSurface.
- */
-const std::string&
-SedSurface::getName() const
-{
-  return mName;
 }
 
 
@@ -288,26 +266,6 @@ SedSurface::getOrder() const
 
 
 /*
- * Predicate returning @c true if this SedSurface's "id" attribute is set.
- */
-bool
-SedSurface::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedSurface's "name" attribute is set.
- */
-bool
-SedSurface::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedSurface's "xDataReference" attribute
  * is set.
  */
@@ -397,28 +355,6 @@ bool
 SedSurface::isSetOrder() const
 {
   return mIsSetOrder;
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedSurface.
- */
-int
-SedSurface::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedSurface.
- */
-int
-SedSurface::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -575,44 +511,6 @@ SedSurface::setOrder(int order)
   mOrder = order;
   mIsSetOrder = true;
   return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedSurface.
- */
-int
-SedSurface::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedSurface.
- */
-int
-SedSurface::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
 }
 
 
@@ -1015,17 +913,7 @@ SedSurface::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "xDataReference")
+  if (attributeName == "xDataReference")
   {
     value = getXDataReference();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -1069,15 +957,7 @@ SedSurface::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "xDataReference")
+  if (attributeName == "xDataReference")
   {
     value = isSetXDataReference();
   }
@@ -1218,15 +1098,7 @@ SedSurface::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "xDataReference")
+  if (attributeName == "xDataReference")
   {
     return_value = setXDataReference(value);
   }
@@ -1264,15 +1136,7 @@ SedSurface::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "xDataReference")
+  if (attributeName == "xDataReference")
   {
     value = unsetXDataReference();
   }
@@ -1326,10 +1190,6 @@ SedSurface::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
   ExpectedAttributes& attributes)
 {
   SedBase::addExpectedAttributes(attributes);
-
-  attributes.add("id");
-
-  attributes.add("name");
 
   attributes.add("xDataReference");
 
@@ -1403,40 +1263,6 @@ SedSurface::readAttributes(
         log->logError(SedmlSurfaceAllowedAttributes, level, version, details,
           getLine(), getColumn());
       }
-    }
-  }
-
-  // 
-  // id SId (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedSurface>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedSurface>");
     }
   }
 
@@ -1681,16 +1507,6 @@ SedSurface::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetXDataReference() == true)
   {

--- a/src/sedml/SedSurface.h
+++ b/src/sedml/SedSurface.h
@@ -99,7 +99,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mXDataReference;
   std::string mYDataReference;
   std::string mZDataReference;
@@ -173,22 +172,6 @@ public:
    * Destructor for SedSurface.
    */
   virtual ~SedSurface();
-
-
-  /**
-   * Returns the value of the "id" attribute of this SedSurface.
-   *
-   * @return the value of the "id" attribute of this SedSurface as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedSurface.
-   *
-   * @return the value of the "name" attribute of this SedSurface as a string.
-   */
-  virtual const std::string& getName() const;
 
 
   /**
@@ -301,24 +284,6 @@ public:
 
 
   /**
-   * Predicate returning @c true if this SedSurface's "id" attribute is set.
-   *
-   * @return @c true if this SedSurface's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedSurface's "name" attribute is set.
-   *
-   * @return @c true if this SedSurface's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
-
-
-  /**
    * Predicate returning @c true if this SedSurface's "xDataReference"
    * attribute is set.
    *
@@ -402,36 +367,6 @@ public:
    * otherwise @c false is returned.
    */
   bool isSetOrder() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedSurface.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedSurface.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
 
 
   /**
@@ -570,26 +505,6 @@ public:
    * OperationReturnValues_t}
    */
   int setOrder(int order);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedSurface.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedSurface.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/src/sedml/SedVariable.cpp
+++ b/src/sedml/SedVariable.cpp
@@ -54,7 +54,6 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedVariable::SedVariable(unsigned int level, unsigned int version)
   : SedBase(level, version)
-  , mName ("")
   , mSymbol ("")
   , mTarget ("")
   , mTaskReference ("")
@@ -63,6 +62,8 @@ SedVariable::SedVariable(unsigned int level, unsigned int version)
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -71,7 +72,6 @@ SedVariable::SedVariable(unsigned int level, unsigned int version)
  */
 SedVariable::SedVariable(SedNamespaces *sedmlns)
   : SedBase(sedmlns)
-  , mName ("")
   , mSymbol ("")
   , mTarget ("")
   , mTaskReference ("")
@@ -80,6 +80,8 @@ SedVariable::SedVariable(SedNamespaces *sedmlns)
 {
   setElementNamespace(sedmlns->getURI());
   connectToChild();
+  mIdAllowedPreV4 = true;
+  mNameAllowedPreV4 = true;
 }
 
 
@@ -88,7 +90,6 @@ SedVariable::SedVariable(SedNamespaces *sedmlns)
  */
 SedVariable::SedVariable(const SedVariable& orig)
   : SedBase( orig )
-  , mName ( orig.mName )
   , mSymbol ( orig.mSymbol )
   , mTarget ( orig.mTarget )
   , mTaskReference ( orig.mTaskReference )
@@ -108,7 +109,6 @@ SedVariable::operator=(const SedVariable& rhs)
   if (&rhs != this)
   {
     SedBase::operator=(rhs);
-    mName = rhs.mName;
     mSymbol = rhs.mSymbol;
     mTarget = rhs.mTarget;
     mTaskReference = rhs.mTaskReference;
@@ -136,26 +136,6 @@ SedVariable::clone() const
  */
 SedVariable::~SedVariable()
 {
-}
-
-
-/*
- * Returns the value of the "id" attribute of this SedVariable.
- */
-const std::string&
-SedVariable::getId() const
-{
-  return mId;
-}
-
-
-/*
- * Returns the value of the "name" attribute of this SedVariable.
- */
-const std::string&
-SedVariable::getName() const
-{
-  return mName;
 }
 
 
@@ -200,26 +180,6 @@ SedVariable::getModelReference() const
 
 
 /*
- * Predicate returning @c true if this SedVariable's "id" attribute is set.
- */
-bool
-SedVariable::isSetId() const
-{
-  return (mId.empty() == false);
-}
-
-
-/*
- * Predicate returning @c true if this SedVariable's "name" attribute is set.
- */
-bool
-SedVariable::isSetName() const
-{
-  return (mName.empty() == false);
-}
-
-
-/*
  * Predicate returning @c true if this SedVariable's "symbol" attribute is set.
  */
 bool
@@ -258,28 +218,6 @@ bool
 SedVariable::isSetModelReference() const
 {
   return (mModelReference.empty() == false);
-}
-
-
-/*
- * Sets the value of the "id" attribute of this SedVariable.
- */
-int
-SedVariable::setId(const std::string& id)
-{
-  mId = id;
-  return LIBSEDML_OPERATION_SUCCESS;
-}
-
-
-/*
- * Sets the value of the "name" attribute of this SedVariable.
- */
-int
-SedVariable::setName(const std::string& name)
-{
-  mName = name;
-  return LIBSEDML_OPERATION_SUCCESS;
 }
 
 
@@ -337,44 +275,6 @@ SedVariable::setModelReference(const std::string& modelReference)
   {
     mModelReference = modelReference;
     return LIBSEDML_OPERATION_SUCCESS;
-  }
-}
-
-
-/*
- * Unsets the value of the "id" attribute of this SedVariable.
- */
-int
-SedVariable::unsetId()
-{
-  mId.erase();
-
-  if (mId.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
-  }
-}
-
-
-/*
- * Unsets the value of the "name" attribute of this SedVariable.
- */
-int
-SedVariable::unsetName()
-{
-  mName.erase();
-
-  if (mName.empty() == true)
-  {
-    return LIBSEDML_OPERATION_SUCCESS;
-  }
-  else
-  {
-    return LIBSEDML_OPERATION_FAILED;
   }
 }
 
@@ -835,17 +735,7 @@ SedVariable::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "id")
-  {
-    value = getId();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "name")
-  {
-    value = getName();
-    return_value = LIBSEDML_OPERATION_SUCCESS;
-  }
-  else if (attributeName == "symbol")
+  if (attributeName == "symbol")
   {
     value = getSymbol();
     return_value = LIBSEDML_OPERATION_SUCCESS;
@@ -884,15 +774,7 @@ SedVariable::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedBase::isSetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = isSetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = isSetName();
-  }
-  else if (attributeName == "symbol")
+  if (attributeName == "symbol")
   {
     value = isSetSymbol();
   }
@@ -996,15 +878,7 @@ SedVariable::setAttribute(const std::string& attributeName,
 {
   int return_value = SedBase::setAttribute(attributeName, value);
 
-  if (attributeName == "id")
-  {
-    return_value = setId(value);
-  }
-  else if (attributeName == "name")
-  {
-    return_value = setName(value);
-  }
-  else if (attributeName == "symbol")
+  if (attributeName == "symbol")
   {
     return_value = setSymbol(value);
   }
@@ -1038,15 +912,7 @@ SedVariable::unsetAttribute(const std::string& attributeName)
 {
   int value = SedBase::unsetAttribute(attributeName);
 
-  if (attributeName == "id")
-  {
-    value = unsetId();
-  }
-  else if (attributeName == "name")
-  {
-    value = unsetName();
-  }
-  else if (attributeName == "symbol")
+  if (attributeName == "symbol")
   {
     value = unsetSymbol();
   }
@@ -1255,10 +1121,6 @@ SedVariable::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedBase::addExpectedAttributes(attributes);
 
-  attributes.add("id");
-
-  attributes.add("name");
-
   attributes.add("symbol");
 
   attributes.add("target");
@@ -1324,26 +1186,7 @@ SedVariable::readAttributes(
     }
   }
 
-  // 
-  // id SId (use = "required" )
-  // 
-
-  assigned = attributes.readInto("id", mId);
-
-  if (assigned == true)
-  {
-    if (mId.empty() == true)
-    {
-      logEmptyString(mId, level, version, "<SedVariable>");
-    }
-    else if (SyntaxChecker::isValidSBMLSId(mId) == false)
-    {
-      logError(SedmlIdSyntaxRule, level, version, "The id on the <" +
-        getElementName() + "> is '" + mId + "', which does not conform to the "
-          "syntax.", getLine(), getColumn());
-    }
-  }
-  else
+  if(!isSetId())
   {
     if (log)
     {
@@ -1351,20 +1194,6 @@ SedVariable::readAttributes(
         "<SedVariable> element.";
       log->logError(SedmlVariableAllowedAttributes, level, version, message,
         getLine(), getColumn());
-    }
-  }
-
-  // 
-  // name string (use = "optional" )
-  // 
-
-  assigned = attributes.readInto("name", mName);
-
-  if (assigned == true)
-  {
-    if (mName.empty() == true)
-    {
-      logEmptyString(mName, level, version, "<SedVariable>");
     }
   }
 
@@ -1467,16 +1296,6 @@ SedVariable::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER XMLOutputStream&
   stream) const
 {
   SedBase::writeAttributes(stream);
-
-  if (isSetId() == true)
-  {
-    stream.writeAttribute("id", getPrefix(), mId);
-  }
-
-  if (isSetName() == true)
-  {
-    stream.writeAttribute("name", getPrefix(), mName);
-  }
 
   if (isSetSymbol() == true)
   {

--- a/src/sedml/SedVariable.h
+++ b/src/sedml/SedVariable.h
@@ -64,7 +64,6 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mName;
   std::string mSymbol;
   std::string mTarget;
   std::string mTaskReference;
@@ -133,22 +132,6 @@ public:
 
 
   /**
-   * Returns the value of the "id" attribute of this SedVariable.
-   *
-   * @return the value of the "id" attribute of this SedVariable as a string.
-   */
-  virtual const std::string& getId() const;
-
-
-  /**
-   * Returns the value of the "name" attribute of this SedVariable.
-   *
-   * @return the value of the "name" attribute of this SedVariable as a string.
-   */
-  virtual const std::string& getName() const;
-
-
-  /**
    * Returns the value of the "symbol" attribute of this SedVariable.
    *
    * @return the value of the "symbol" attribute of this SedVariable as a
@@ -182,24 +165,6 @@ public:
    * a string.
    */
   const std::string& getModelReference() const;
-
-
-  /**
-   * Predicate returning @c true if this SedVariable's "id" attribute is set.
-   *
-   * @return @c true if this SedVariable's "id" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetId() const;
-
-
-  /**
-   * Predicate returning @c true if this SedVariable's "name" attribute is set.
-   *
-   * @return @c true if this SedVariable's "name" attribute has been set,
-   * otherwise @c false is returned.
-   */
-  virtual bool isSetName() const;
 
 
   /**
@@ -240,36 +205,6 @@ public:
    * set, otherwise @c false is returned.
    */
   bool isSetModelReference() const;
-
-
-  /**
-   * Sets the value of the "id" attribute of this SedVariable.
-   *
-   * @param id std::string& value of the "id" attribute to be set.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
-   * OperationReturnValues_t}
-   *
-   * Calling this function with @p id = @c NULL or an empty string is
-   * equivalent to calling unsetId().
-   */
-  virtual int setId(const std::string& id);
-
-
-  /**
-   * Sets the value of the "name" attribute of this SedVariable.
-   *
-   * @param name std::string& value of the "name" attribute to be set.
-   *
-   * @copydetails doc_returns_one_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   *
-   * Calling this function with @p name = @c NULL or an empty string is
-   * equivalent to calling unsetName().
-   */
-  virtual int setName(const std::string& name);
 
 
   /**
@@ -326,26 +261,6 @@ public:
    * OperationReturnValues_t}
    */
   int setModelReference(const std::string& modelReference);
-
-
-  /**
-   * Unsets the value of the "id" attribute of this SedVariable.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetId();
-
-
-  /**
-   * Unsets the value of the "name" attribute of this SedVariable.
-   *
-   * @copydetails doc_returns_success_code
-   * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
-   * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
-   */
-  virtual int unsetName();
 
 
   /**

--- a/tests/TestIssues.cpp
+++ b/tests/TestIssues.cpp
@@ -423,27 +423,177 @@ TEST_CASE("Reading / Writing changexml only text node", "[sedml]")
 }
 
 
-
-
-
 TEST_CASE("Reading numberOfPoints", "[sedml]")
 {
-  std::string fileName = getTestFile("/test-data/issue_93.sedml");
-  SedDocument* doc = readSedMLFromFile(fileName.c_str());
-  bool haveErrors = doc->getNumErrors(LIBSEDML_SEV_ERROR) != 0;
-  
-  if (haveErrors)
-    doc->getErrorLog()->printErrors();
-  
-  REQUIRE(!haveErrors);
+    std::string fileName = getTestFile("/test-data/issue_93.sedml");
+    SedDocument* doc = readSedMLFromFile(fileName.c_str());
+    bool haveErrors = doc->getNumErrors(LIBSEDML_SEV_ERROR) != 0;
 
-  {
-    auto* task = dynamic_cast<SedRepeatedTask*> (doc->getTask(0));
-    REQUIRE(task != NULL);
-    auto* range = dynamic_cast<SedUniformRange*> (task->getRange(0));
-    REQUIRE(range != NULL);
-    REQUIRE(range->isSetNumberOfPoints());
-    REQUIRE(range->getNumberOfPoints() == 10);
-  }
-  delete doc;
+    if (haveErrors)
+        doc->getErrorLog()->printErrors();
+
+    REQUIRE(!haveErrors);
+
+    {
+        auto* task = dynamic_cast<SedRepeatedTask*> (doc->getTask(0));
+        REQUIRE(task != NULL);
+        auto* range = dynamic_cast<SedUniformRange*> (task->getRange(0));
+        REQUIRE(range != NULL);
+        REQUIRE(range->isSetNumberOfPoints());
+        REQUIRE(range->getNumberOfPoints() == 10);
+    }
+    delete doc;
+}
+
+
+
+TEST_CASE("Id and name on different levels/versions", "[sedml]")
+{
+    SedNamespaces l1v3(1, 3);
+    SedNamespaces l1v4(1, 4);
+
+    //An element that had name and id in l1v3
+    SedVariable variable13(&l1v3), variable14(&l1v4);
+    CHECK(variable13.isSetId() == false);
+    CHECK(variable14.isSetId() == false);
+    CHECK(variable13.getId() == "");
+    CHECK(variable14.getId() == "");
+    CHECK(variable13.setId("variable") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable14.setId("variable") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable13.isSetId() == true);
+    CHECK(variable14.isSetId() == true);
+    CHECK(variable13.getId() == "variable");
+    CHECK(variable14.getId() == "variable");
+    CHECK(variable13.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable14.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable13.isSetId() == false);
+    CHECK(variable14.isSetId() == false);
+    CHECK(variable13.getId() == "");
+    CHECK(variable14.getId() == "");
+
+    CHECK(variable13.isSetName() == false);
+    CHECK(variable14.isSetName() == false);
+    CHECK(variable13.getName() == "");
+    CHECK(variable14.getName() == "");
+    CHECK(variable13.setName("variable") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable14.setName("variable") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable13.isSetName() == true);
+    CHECK(variable14.isSetName() == true);
+    CHECK(variable13.getName() == "variable");
+    CHECK(variable14.getName() == "variable");
+    CHECK(variable13.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable14.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(variable13.isSetName() == false);
+    CHECK(variable14.isSetName() == false);
+    CHECK(variable13.getName() == "");
+    CHECK(variable14.getName() == "");
+
+    //An element that had name but not id in l1v3:
+    SedCurve curve13(&l1v3), curve14(&l1v4);
+    CHECK(curve13.isSetId() == false);
+    CHECK(curve14.isSetId() == false);
+    CHECK(curve13.getId() == "");
+    CHECK(curve14.getId() == "");
+    CHECK(curve13.setId("curve") == LIBSEDML_UNEXPECTED_ATTRIBUTE);
+    CHECK(curve14.setId("curve") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve13.isSetId() == false);
+    CHECK(curve14.isSetId() == true);
+    CHECK(curve13.getId() == "");
+    CHECK(curve14.getId() == "curve");
+    CHECK(curve13.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve14.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve13.isSetId() == false);
+    CHECK(curve14.isSetId() == false);
+    CHECK(curve13.getId() == "");
+    CHECK(curve14.getId() == "");
+
+    CHECK(curve13.isSetName() == false);
+    CHECK(curve14.isSetName() == false);
+    CHECK(curve13.getName() == "");
+    CHECK(curve14.getName() == "");
+    CHECK(curve13.setName("curve") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve14.setName("curve") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve13.isSetName() == true);
+    CHECK(curve14.isSetName() == true);
+    CHECK(curve13.getName() == "curve");
+    CHECK(curve14.getName() == "curve");
+    CHECK(curve13.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve14.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(curve13.isSetName() == false);
+    CHECK(curve14.isSetName() == false);
+    CHECK(curve13.getName() == "");
+    CHECK(curve14.getName() == "");
+
+    //An element that had id but not name in l1v3:
+    SedRange range13(&l1v3), range14(&l1v4);
+    CHECK(range13.isSetId() == false);
+    CHECK(range14.isSetId() == false);
+    CHECK(range13.getId() == "");
+    CHECK(range14.getId() == "");
+    CHECK(range13.setId("range") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range14.setId("range") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range13.isSetId() == true);
+    CHECK(range14.isSetId() == true);
+    CHECK(range13.getId() == "range");
+    CHECK(range14.getId() == "range");
+    CHECK(range13.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range14.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range13.isSetId() == false);
+    CHECK(range14.isSetId() == false);
+    CHECK(range13.getId() == "");
+    CHECK(range14.getId() == "");
+
+    CHECK(range13.isSetName() == false);
+    CHECK(range14.isSetName() == false);
+    CHECK(range13.getName() == "");
+    CHECK(range14.getName() == "");
+    CHECK(range13.setName("range") == LIBSEDML_UNEXPECTED_ATTRIBUTE);
+    CHECK(range14.setName("range") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range13.isSetName() == false);
+    CHECK(range14.isSetName() == true);
+    CHECK(range13.getName() == "");
+    CHECK(range14.getName() == "range");
+    CHECK(range13.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range14.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(range13.isSetName() == false);
+    CHECK(range14.isSetName() == false);
+    CHECK(range13.getName() == "");
+    CHECK(range14.getName() == "");
+
+    //An element that didn't have id or name in l1v3:
+    SedAlgorithm algorithm13(&l1v3), algorithm14(&l1v4);
+    CHECK(algorithm13.isSetId() == false);
+    CHECK(algorithm14.isSetId() == false);
+    CHECK(algorithm13.getId() == "");
+    CHECK(algorithm14.getId() == "");
+    CHECK(algorithm13.setId("algorithm") == LIBSEDML_UNEXPECTED_ATTRIBUTE);
+    CHECK(algorithm14.setId("algorithm") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm13.isSetId() == false);
+    CHECK(algorithm14.isSetId() == true);
+    CHECK(algorithm13.getId() == "");
+    CHECK(algorithm14.getId() == "algorithm");
+    CHECK(algorithm13.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm14.unsetId() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm13.isSetId() == false);
+    CHECK(algorithm14.isSetId() == false);
+    CHECK(algorithm13.getId() == "");
+    CHECK(algorithm14.getId() == "");
+
+    CHECK(algorithm13.isSetName() == false);
+    CHECK(algorithm14.isSetName() == false);
+    CHECK(algorithm13.getName() == "");
+    CHECK(algorithm14.getName() == "");
+    CHECK(algorithm13.setName("algorithm") == LIBSEDML_UNEXPECTED_ATTRIBUTE);
+    CHECK(algorithm14.setName("algorithm") == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm13.isSetName() == false);
+    CHECK(algorithm14.isSetName() == true);
+    CHECK(algorithm13.getName() == "");
+    CHECK(algorithm14.getName() == "algorithm");
+    CHECK(algorithm13.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm14.unsetName() == LIBSEDML_OPERATION_SUCCESS);
+    CHECK(algorithm13.isSetName() == false);
+    CHECK(algorithm14.isSetName() == false);
+    CHECK(algorithm13.getName() == "");
+    CHECK(algorithm14.getName() == "");
+
 }

--- a/tests/TestIssues.cpp
+++ b/tests/TestIssues.cpp
@@ -494,11 +494,11 @@ TEST_CASE("Id and name on different levels/versions", "[sedml]")
     CHECK(curve14.isSetId() == false);
     CHECK(curve13.getId() == "");
     CHECK(curve14.getId() == "");
-    CHECK(curve13.setId("curve") == LIBSEDML_UNEXPECTED_ATTRIBUTE);
+    CHECK(curve13.setId("curve") == LIBSEDML_OPERATION_SUCCESS);
     CHECK(curve14.setId("curve") == LIBSEDML_OPERATION_SUCCESS);
-    CHECK(curve13.isSetId() == false);
+    CHECK(curve13.isSetId() == true);
     CHECK(curve14.isSetId() == true);
-    CHECK(curve13.getId() == "");
+    CHECK(curve13.getId() == "curve");
     CHECK(curve14.getId() == "curve");
     CHECK(curve13.unsetId() == LIBSEDML_OPERATION_SUCCESS);
     CHECK(curve14.unsetId() == LIBSEDML_OPERATION_SUCCESS);


### PR DESCRIPTION
This change moves all functionality with respect to id and name to SedBase, so the bulk of the change is simply 'deleted code'.

In L1v4, everything has an id and name, so everything works fine there.

In L1v3 and earlier, some elements had id and name, some had just id, some had just name, and some had neither.  This is now handled with the 'mIdAllowedPreV4' and 'mNameAllowedPreV4' boolean member variables on SedBase, which the relevant classes define in their constructors, and then checked in the various SedBase functions that set/get/unset/read/write the id and name attributes.  The exception is that the 'id is required' functionality is still handled in 'readAttributes', but instead of setting the id and then checking if it's set, it now just calls SedBase::readAttributes and then checks 'isSetId()'.