### PR TITLE
Change taskRef to taskReference

### DIFF
--- a/dev/sedml.xml
+++ b/dev/sedml.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="SEDML" fullname="SEDML" number="100" offset="100000" version="1" required="false">
-  <language name="SedML" baseClass="SedBase" documentClass="SedDocument" prefix="Sed" libraryName="LibSEDML"/>
+<package name="SEDML" fullname="SEDML" number="100" offset="100000" version="1" required="false" customCopyright="sedml_copyright.txt">
+  <language name="SedML" baseClass="SedBase" documentClass="SedDocument" prefix="Sed" libraryName="LibSEDML" annotationElementName="Annotation" topLevelElementName="Annotation" isPackage="false" uses_ASTNode="true" uses_XMLNode="true">
+    <library_version major="1" minor="0" revision="0"/>
+    <language_versions>
+      <version level="1" version="1" namespace="http://sed-ml.org/"/>
+    </language_versions>
+    <dependencies>
+      <dependency library_name="libnuml" prefix="NUML"/>
+    </dependencies>
+  </language>
   <versions>
     <pkgVersion level="1" version="1" pkg_version="1">
       <elements>
@@ -541,7 +549,6 @@
       <mappings>
         <mapping name="DimensionDescription" package="numl"/>
         <mapping name="SedBase"/>
-        <mapping name="DependentVariable"/>
       </mappings>
     </pkgVersion>
   </versions>

--- a/dev/sedml.xml
+++ b/dev/sedml.xml
@@ -1,14 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package name="SEDML" fullname="SEDML" number="100" offset="100000" version="1" required="false" customCopyright="sedml_copyright.txt">
-  <language name="SedML" baseClass="SedBase" documentClass="SedDocument" prefix="Sed" libraryName="LibSEDML" annotationElementName="Annotation" topLevelElementName="Annotation" isPackage="false" uses_ASTNode="true" uses_XMLNode="true">
-    <library_version major="1" minor="0" revision="0"/>
-    <language_versions>
-      <version level="1" version="1" namespace="http://sed-ml.org/"/>
-    </language_versions>
-    <dependencies>
-      <dependency library_name="libnuml" prefix="NUML"/>
-    </dependencies>
-  </language>
+<package name="SEDML" fullname="SEDML" number="100" offset="100000" version="1" required="false">
+  <language name="SedML" baseClass="SedBase" documentClass="SedDocument" prefix="Sed" libraryName="LibSEDML"/>
   <versions>
     <pkgVersion level="1" version="1" pkg_version="1">
       <elements>
@@ -456,7 +448,7 @@
         </element>
         <element name="ParameterEstimationResultPlot" typeCode="SEDML_PARAMETERESTIMATIONRESULTPLOT" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Plot" abstract="false">
           <attributes>
-            <attribute name="taskRef" required="true" type="SIdRef" element="Task" abstract="false"/>
+            <attribute name="taskReference" required="true" type="SIdRef" element="Task" abstract="false"/>
           </attributes>
         </element>
         <element name="WaterfallPlot" typeCode="SEDML_WATERFALLPLOT" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Plot" abstract="false">
@@ -549,6 +541,7 @@
       <mappings>
         <mapping name="DimensionDescription" package="numl"/>
         <mapping name="SedBase"/>
+        <mapping name="DependentVariable"/>
       </mappings>
     </pkgVersion>
   </versions>

--- a/src/sedml/SedError.h
+++ b/src/sedml/SedError.h
@@ -457,15 +457,15 @@ typedef enum
 , SedmlParameterEstimationResultPlotAllowedCoreAttributes      = 26001
 , SedmlParameterEstimationResultPlotAllowedCoreElements      = 26002
 , SedmlParameterEstimationResultPlotAllowedAttributes      = 26003
-, SedmlParameterEstimationResultPlotTaskRefMustBeTask      = 26004
+, SedmlParameterEstimationResultPlotTaskReferenceMustBeTask      = 26004
 , SedmlWaterfallPlotAllowedCoreAttributes      = 26101
 , SedmlWaterfallPlotAllowedCoreElements      = 26102
 , SedmlWaterfallPlotAllowedAttributes      = 26103
-, SedmlWaterfallPlotTaskRefMustBeTask      = 26104
+, SedmlWaterfallPlotTaskReferenceMustBeTask      = 26104
 , SedmlParameterEstimationReportAllowedCoreAttributes      = 26201
 , SedmlParameterEstimationReportAllowedCoreElements      = 26202
 , SedmlParameterEstimationReportAllowedAttributes      = 26203
-, SedmlParameterEstimationReportTaskRefMustBeTask      = 26204
+, SedmlParameterEstimationReportTaskReferenceMustBeTask      = 26204
 , SedUnknownCoreAttribute                  = 99994 /*!< Encountered an unknown attribute in the SED-ML Core namespace. */
 , SedCodesUpperBound                   = 99999 /*!< Upper boundary of libSEDML-specific diagnostic codes. */
 } SedErrorCode_t;

--- a/src/sedml/SedErrorTable.h
+++ b/src/sedml/SedErrorTable.h
@@ -4906,18 +4906,18 @@ static const sedmlErrorTableEntry sedmlErrorTable[] =
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
     "A <parameterEstimationResultPlot> object must have the required attribute "
-    "'sedml:taskRef'. No other attributes from the SBML Level 3 SED-ML "
+    "'sedml:taskReference'. No other attributes from the SBML Level 3 SED-ML "
     "namespaces are permitted on a <parameterEstimationResultPlot> object. ",
     { "L3V1 Sedml V1 Section"
     }
   },
 
   // 26004
-  { SedmlParameterEstimationResultPlotTaskRefMustBeTask,
-    "The attribute 'taskRef' must point to Task object.",
+  { SedmlParameterEstimationResultPlotTaskReferenceMustBeTask,
+    "The attribute 'taskReference' must point to Task object.",
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
-    "The value of the attribute 'sedml:taskRef' of a "
+    "The value of the attribute 'sedml:taskReference' of a "
     "<parameterEstimationResultPlot> object must be the identifier of an "
     "existing <task> object defined in the enclosing <model> object.",
     { "L3V1 Sedml V1 Section"
@@ -4953,7 +4953,7 @@ static const sedmlErrorTableEntry sedmlErrorTable[] =
     "Attributes allowed on <waterfallPlot>.",
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
-    "A <waterfallPlot> object must have the required attribute 'sedml:taskRef'. "
+    "A <waterfallPlot> object must have the required attribute 'sedml:taskReference'. "
     "No other attributes from the SBML Level 3 SED-ML namespaces are permitted "
     "on a <waterfallPlot> object. ",
     { "L3V1 Sedml V1 Section"
@@ -4961,11 +4961,11 @@ static const sedmlErrorTableEntry sedmlErrorTable[] =
   },
 
   // 26104
-  { SedmlWaterfallPlotTaskRefMustBeTask,
-    "The attribute 'taskRef' must point to Task object.",
+  { SedmlWaterfallPlotTaskReferenceMustBeTask,
+    "The attribute 'taskReference' must point to Task object.",
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
-    "The value of the attribute 'sedml:taskRef' of a <waterfallPlot> object "
+    "The value of the attribute 'sedml:taskReference' of a <waterfallPlot> object "
     "must be the identifier of an existing <task> object defined in the "
     "enclosing <model> object.",
     { "L3V1 Sedml V1 Section"
@@ -5002,18 +5002,18 @@ static const sedmlErrorTableEntry sedmlErrorTable[] =
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
     "A <parameterEstimationReport> object must have the required attribute "
-    "'sedml:taskRef'. No other attributes from the SBML Level 3 SED-ML "
+    "'sedml:taskReference'. No other attributes from the SBML Level 3 SED-ML "
     "namespaces are permitted on a <parameterEstimationReport> object. ",
     { "L3V1 Sedml V1 Section"
     }
   },
 
   // 26204
-  { SedmlParameterEstimationReportTaskRefMustBeTask,
-    "The attribute 'taskRef' must point to Task object.",
+  { SedmlParameterEstimationReportTaskReferenceMustBeTask,
+    "The attribute 'taskReference' must point to Task object.",
     LIBSEDML_CAT_GENERAL_CONSISTENCY,
     LIBSEDML_SEV_ERROR,
-    "The value of the attribute 'sedml:taskRef' of a "
+    "The value of the attribute 'sedml:taskReference' of a "
     "<parameterEstimationReport> object must be the identifier of an existing "
     "<task> object defined in the enclosing <model> object.",
     { "L3V1 Sedml V1 Section"

--- a/src/sedml/SedParameterEstimationReport.cpp
+++ b/src/sedml/SedParameterEstimationReport.cpp
@@ -55,7 +55,7 @@ SedParameterEstimationReport::SedParameterEstimationReport(unsigned int level,
                                                            unsigned int
                                                              version)
   : SedOutput(level, version)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
 }
@@ -68,7 +68,7 @@ SedParameterEstimationReport::SedParameterEstimationReport(unsigned int level,
 SedParameterEstimationReport::SedParameterEstimationReport(SedNamespaces
   *sedmlns)
   : SedOutput(sedmlns)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setElementNamespace(sedmlns->getURI());
 }
@@ -80,7 +80,7 @@ SedParameterEstimationReport::SedParameterEstimationReport(SedNamespaces
 SedParameterEstimationReport::SedParameterEstimationReport(const
   SedParameterEstimationReport& orig)
   : SedOutput( orig )
-  , mTaskRef ( orig.mTaskRef )
+  , mTaskReference ( orig.mTaskReference )
 {
 }
 
@@ -95,7 +95,7 @@ SedParameterEstimationReport::operator=(const SedParameterEstimationReport&
   if (&rhs != this)
   {
     SedOutput::operator=(rhs);
-    mTaskRef = rhs.mTaskRef;
+    mTaskReference = rhs.mTaskReference;
   }
 
   return *this;
@@ -121,56 +121,56 @@ SedParameterEstimationReport::~SedParameterEstimationReport()
 
 
 /*
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationReport.
  */
 const std::string&
-SedParameterEstimationReport::getTaskRef() const
+SedParameterEstimationReport::getTaskReference() const
 {
-  return mTaskRef;
+  return mTaskReference;
 }
 
 
 /*
- * Predicate returning @c true if this SedParameterEstimationReport's "taskRef"
+ * Predicate returning @c true if this SedParameterEstimationReport's "taskReference"
  * attribute is set.
  */
 bool
-SedParameterEstimationReport::isSetTaskRef() const
+SedParameterEstimationReport::isSetTaskReference() const
 {
-  return (mTaskRef.empty() == false);
+  return (mTaskReference.empty() == false);
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport.
  */
 int
-SedParameterEstimationReport::setTaskRef(const std::string& taskRef)
+SedParameterEstimationReport::setTaskReference(const std::string& taskReference)
 {
-  if (!(SyntaxChecker::isValidInternalSId(taskRef)))
+  if (!(SyntaxChecker::isValidInternalSId(taskReference)))
   {
     return LIBSEDML_INVALID_ATTRIBUTE_VALUE;
   }
   else
   {
-    mTaskRef = taskRef;
+    mTaskReference = taskReference;
     return LIBSEDML_OPERATION_SUCCESS;
   }
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport.
  */
 int
-SedParameterEstimationReport::unsetTaskRef()
+SedParameterEstimationReport::unsetTaskReference()
 {
-  mTaskRef.erase();
+  mTaskReference.erase();
 
-  if (mTaskRef.empty() == true)
+  if (mTaskReference.empty() == true)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -188,9 +188,9 @@ void
 SedParameterEstimationReport::renameSIdRefs(const std::string& oldid,
                                             const std::string& newid)
 {
-  if (isSetTaskRef() && mTaskRef == oldid)
+  if (isSetTaskReference() && mTaskReference == oldid)
   {
-    setTaskRef(newid);
+    setTaskReference(newid);
   }
 }
 
@@ -225,7 +225,7 @@ SedParameterEstimationReport::hasRequiredAttributes() const
 {
   bool allPresent = SedOutput::hasRequiredAttributes();
 
-  if (isSetTaskRef() == false)
+  if (isSetTaskReference() == false)
   {
     allPresent = false;
   }
@@ -374,9 +374,9 @@ SedParameterEstimationReport::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = getTaskRef();
+    value = getTaskReference();
     return_value = LIBSEDML_OPERATION_SUCCESS;
   }
 
@@ -399,9 +399,9 @@ SedParameterEstimationReport::isSetAttribute(const std::string& attributeName)
 {
   bool value = SedOutput::isSetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = isSetTaskRef();
+    value = isSetTaskReference();
   }
 
   return value;
@@ -499,9 +499,9 @@ SedParameterEstimationReport::setAttribute(const std::string& attributeName,
 {
   int return_value = SedOutput::setAttribute(attributeName, value);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    return_value = setTaskRef(value);
+    return_value = setTaskReference(value);
   }
 
   return return_value;
@@ -522,9 +522,9 @@ SedParameterEstimationReport::unsetAttribute(const std::string& attributeName)
 {
   int value = SedOutput::unsetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = unsetTaskRef();
+    value = unsetTaskReference();
   }
 
   return value;
@@ -565,7 +565,7 @@ SedParameterEstimationReport::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIF
 {
   SedOutput::addExpectedAttributes(attributes);
 
-  attributes.add("taskRef");
+  attributes.add("taskReference");
 }
 
 /** @endcond */
@@ -610,29 +610,29 @@ SedParameterEstimationReport::readAttributes(
   }
 
   // 
-  // taskRef SIdRef (use = "required" )
+  // taskReference SIdRef (use = "required" )
   // 
 
-  assigned = attributes.readInto("taskRef", mTaskRef);
+  assigned = attributes.readInto("taskReference", mTaskReference);
 
   if (assigned == true)
   {
-    if (mTaskRef.empty() == true)
+    if (mTaskReference.empty() == true)
     {
-      logEmptyString(mTaskRef, level, version,
+      logEmptyString(mTaskReference, level, version,
         "<SedParameterEstimationReport>");
     }
-    else if (SyntaxChecker::isValidSBMLSId(mTaskRef) == false)
+    else if (SyntaxChecker::isValidSBMLSId(mTaskReference) == false)
     {
-      std::string msg = "The taskRef attribute on the <" + getElementName() +
+      std::string msg = "The taskReference attribute on the <" + getElementName() +
         ">";
       if (isSetId())
       {
         msg += " with id '" + getId() + "'";
       }
 
-      msg += " is '" + mTaskRef + "', which does not conform to the syntax.";
-      logError(SedmlParameterEstimationReportTaskRefMustBeTask, level, version,
+      msg += " is '" + mTaskReference + "', which does not conform to the syntax.";
+      logError(SedmlParameterEstimationReportTaskReferenceMustBeTask, level, version,
         msg, getLine(), getColumn());
     }
   }
@@ -640,7 +640,7 @@ SedParameterEstimationReport::readAttributes(
   {
     if (log)
     {
-      std::string message = "Sedml attribute 'taskRef' is missing from the "
+      std::string message = "Sedml attribute 'taskReference' is missing from the "
         "<SedParameterEstimationReport> element.";
       log->logError(SedmlParameterEstimationReportAllowedAttributes, level,
         version, message, getLine(), getColumn());
@@ -663,9 +663,9 @@ SedParameterEstimationReport::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedOutput::writeAttributes(stream);
 
-  if (isSetTaskRef() == true)
+  if (isSetTaskReference() == true)
   {
-    stream.writeAttribute("taskRef", getPrefix(), mTaskRef);
+    stream.writeAttribute("taskReference", getPrefix(), mTaskReference);
   }
 }
 
@@ -723,12 +723,12 @@ SedParameterEstimationReport_free(SedParameterEstimationReport_t* sper)
 
 
 /*
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  */
 LIBSEDML_EXTERN
 char *
-SedParameterEstimationReport_getTaskRef(const SedParameterEstimationReport_t *
+SedParameterEstimationReport_getTaskReference(const SedParameterEstimationReport_t *
   sper)
 {
   if (sper == NULL)
@@ -736,47 +736,47 @@ SedParameterEstimationReport_getTaskRef(const SedParameterEstimationReport_t *
     return NULL;
   }
 
-  return sper->getTaskRef().empty() ? NULL :
-    safe_strdup(sper->getTaskRef().c_str());
+  return sper->getTaskReference().empty() ? NULL :
+    safe_strdup(sper->getTaskReference().c_str());
 }
 
 
 /*
  * Predicate returning @c 1 (true) if this SedParameterEstimationReport_t's
- * "taskRef" attribute is set.
+ * "taskReference" attribute is set.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_isSetTaskRef(const SedParameterEstimationReport_t
+SedParameterEstimationReport_isSetTaskReference(const SedParameterEstimationReport_t
   * sper)
 {
-  return (sper != NULL) ? static_cast<int>(sper->isSetTaskRef()) : 0;
+  return (sper != NULL) ? static_cast<int>(sper->isSetTaskReference()) : 0;
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_setTaskRef(SedParameterEstimationReport_t * sper,
-                                        const char * taskRef)
+SedParameterEstimationReport_setTaskReference(SedParameterEstimationReport_t * sper,
+                                        const char * taskReference)
 {
-  return (sper != NULL) ? sper->setTaskRef(taskRef) : LIBSEDML_INVALID_OBJECT;
+  return (sper != NULL) ? sper->setTaskReference(taskReference) : LIBSEDML_INVALID_OBJECT;
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_unsetTaskRef(SedParameterEstimationReport_t *
+SedParameterEstimationReport_unsetTaskReference(SedParameterEstimationReport_t *
   sper)
 {
-  return (sper != NULL) ? sper->unsetTaskRef() : LIBSEDML_INVALID_OBJECT;
+  return (sper != NULL) ? sper->unsetTaskReference() : LIBSEDML_INVALID_OBJECT;
 }
 
 

--- a/src/sedml/SedParameterEstimationReport.h
+++ b/src/sedml/SedParameterEstimationReport.h
@@ -63,7 +63,7 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mTaskRef;
+  std::string mTaskReference;
 
   /** @endcond */
 
@@ -130,48 +130,48 @@ public:
 
 
   /**
-   * Returns the value of the "taskRef" attribute of this
+   * Returns the value of the "taskReference" attribute of this
    * SedParameterEstimationReport.
    *
-   * @return the value of the "taskRef" attribute of this
+   * @return the value of the "taskReference" attribute of this
    * SedParameterEstimationReport as a string.
    */
-  const std::string& getTaskRef() const;
+  const std::string& getTaskReference() const;
 
 
   /**
    * Predicate returning @c true if this SedParameterEstimationReport's
-   * "taskRef" attribute is set.
+   * "taskReference" attribute is set.
    *
-   * @return @c true if this SedParameterEstimationReport's "taskRef" attribute
+   * @return @c true if this SedParameterEstimationReport's "taskReference" attribute
    * has been set, otherwise @c false is returned.
    */
-  bool isSetTaskRef() const;
+  bool isSetTaskReference() const;
 
 
   /**
-   * Sets the value of the "taskRef" attribute of this
+   * Sets the value of the "taskReference" attribute of this
    * SedParameterEstimationReport.
    *
-   * @param taskRef std::string& value of the "taskRef" attribute to be set.
+   * @param taskReference std::string& value of the "taskReference" attribute to be set.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
    * OperationReturnValues_t}
    */
-  int setTaskRef(const std::string& taskRef);
+  int setTaskReference(const std::string& taskReference);
 
 
   /**
-   * Unsets the value of the "taskRef" attribute of this
+   * Unsets the value of the "taskReference" attribute of this
    * SedParameterEstimationReport.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
    */
-  int unsetTaskRef();
+  int unsetTaskReference();
 
 
   /**
@@ -219,7 +219,7 @@ public:
    *
    * @note The required attributes for the SedParameterEstimationReport object
    * are:
-   * @li "taskRef"
+   * @li "taskReference"
    */
   virtual bool hasRequiredAttributes() const;
 
@@ -640,13 +640,13 @@ SedParameterEstimationReport_free(SedParameterEstimationReport_t* sper);
 
 
 /**
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  *
- * @param sper the SedParameterEstimationReport_t structure whose taskRef is
+ * @param sper the SedParameterEstimationReport_t structure whose taskReference is
  * sought.
  *
- * @return the value of the "taskRef" attribute of this
+ * @return the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t as a pointer to a string.
  *
  * @copydetails doc_returned_owned_char
@@ -655,34 +655,34 @@ SedParameterEstimationReport_free(SedParameterEstimationReport_t* sper);
  */
 LIBSEDML_EXTERN
 char *
-SedParameterEstimationReport_getTaskRef(const SedParameterEstimationReport_t *
+SedParameterEstimationReport_getTaskReference(const SedParameterEstimationReport_t *
   sper);
 
 
 /**
  * Predicate returning @c 1 (true) if this SedParameterEstimationReport_t's
- * "taskRef" attribute is set.
+ * "taskReference" attribute is set.
  *
  * @param sper the SedParameterEstimationReport_t structure.
  *
- * @return @c 1 (true) if this SedParameterEstimationReport_t's "taskRef"
+ * @return @c 1 (true) if this SedParameterEstimationReport_t's "taskReference"
  * attribute has been set, otherwise @c 0 (false) is returned.
  *
  * @memberof SedParameterEstimationReport_t
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_isSetTaskRef(const SedParameterEstimationReport_t
+SedParameterEstimationReport_isSetTaskReference(const SedParameterEstimationReport_t
   * sper);
 
 
 /**
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  *
  * @param sper the SedParameterEstimationReport_t structure.
  *
- * @param taskRef const char * value of the "taskRef" attribute to be set.
+ * @param taskReference const char * value of the "taskReference" attribute to be set.
  *
  * @copydetails doc_returns_success_code
  * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
@@ -694,12 +694,12 @@ SedParameterEstimationReport_isSetTaskRef(const SedParameterEstimationReport_t
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_setTaskRef(SedParameterEstimationReport_t * sper,
-                                        const char * taskRef);
+SedParameterEstimationReport_setTaskReference(SedParameterEstimationReport_t * sper,
+                                        const char * taskReference);
 
 
 /**
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationReport_t.
  *
  * @param sper the SedParameterEstimationReport_t structure.
@@ -713,7 +713,7 @@ SedParameterEstimationReport_setTaskRef(SedParameterEstimationReport_t * sper,
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationReport_unsetTaskRef(SedParameterEstimationReport_t *
+SedParameterEstimationReport_unsetTaskReference(SedParameterEstimationReport_t *
   sper);
 
 
@@ -730,7 +730,7 @@ SedParameterEstimationReport_unsetTaskRef(SedParameterEstimationReport_t *
  *
  * @note The required attributes for the SedParameterEstimationReport_t object
  * are:
- * @li "taskRef"
+ * @li "taskReference"
  *
  * @memberof SedParameterEstimationReport_t
  */

--- a/src/sedml/SedParameterEstimationResultPlot.cpp
+++ b/src/sedml/SedParameterEstimationResultPlot.cpp
@@ -57,7 +57,7 @@ SedParameterEstimationResultPlot::SedParameterEstimationResultPlot(
                                                                    unsigned int
                                                                      version)
   : SedPlot(level, version)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
 }
@@ -70,7 +70,7 @@ SedParameterEstimationResultPlot::SedParameterEstimationResultPlot(
 SedParameterEstimationResultPlot::SedParameterEstimationResultPlot(SedNamespaces
   *sedmlns)
   : SedPlot(sedmlns)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setElementNamespace(sedmlns->getURI());
 }
@@ -82,7 +82,7 @@ SedParameterEstimationResultPlot::SedParameterEstimationResultPlot(SedNamespaces
 SedParameterEstimationResultPlot::SedParameterEstimationResultPlot(const
   SedParameterEstimationResultPlot& orig)
   : SedPlot( orig )
-  , mTaskRef ( orig.mTaskRef )
+  , mTaskReference ( orig.mTaskReference )
 {
 }
 
@@ -97,7 +97,7 @@ SedParameterEstimationResultPlot::operator=(const
   if (&rhs != this)
   {
     SedPlot::operator=(rhs);
-    mTaskRef = rhs.mTaskRef;
+    mTaskReference = rhs.mTaskReference;
   }
 
   return *this;
@@ -124,56 +124,56 @@ SedParameterEstimationResultPlot::~SedParameterEstimationResultPlot()
 
 
 /*
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot.
  */
 const std::string&
-SedParameterEstimationResultPlot::getTaskRef() const
+SedParameterEstimationResultPlot::getTaskReference() const
 {
-  return mTaskRef;
+  return mTaskReference;
 }
 
 
 /*
  * Predicate returning @c true if this SedParameterEstimationResultPlot's
- * "taskRef" attribute is set.
+ * "taskReference" attribute is set.
  */
 bool
-SedParameterEstimationResultPlot::isSetTaskRef() const
+SedParameterEstimationResultPlot::isSetTaskReference() const
 {
-  return (mTaskRef.empty() == false);
+  return (mTaskReference.empty() == false);
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot.
  */
 int
-SedParameterEstimationResultPlot::setTaskRef(const std::string& taskRef)
+SedParameterEstimationResultPlot::setTaskReference(const std::string& taskReference)
 {
-  if (!(SyntaxChecker::isValidInternalSId(taskRef)))
+  if (!(SyntaxChecker::isValidInternalSId(taskReference)))
   {
     return LIBSEDML_INVALID_ATTRIBUTE_VALUE;
   }
   else
   {
-    mTaskRef = taskRef;
+    mTaskReference = taskReference;
     return LIBSEDML_OPERATION_SUCCESS;
   }
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot.
  */
 int
-SedParameterEstimationResultPlot::unsetTaskRef()
+SedParameterEstimationResultPlot::unsetTaskReference()
 {
-  mTaskRef.erase();
+  mTaskReference.erase();
 
-  if (mTaskRef.empty() == true)
+  if (mTaskReference.empty() == true)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -191,9 +191,9 @@ void
 SedParameterEstimationResultPlot::renameSIdRefs(const std::string& oldid,
                                                 const std::string& newid)
 {
-  if (isSetTaskRef() && mTaskRef == oldid)
+  if (isSetTaskReference() && mTaskReference == oldid)
   {
-    setTaskRef(newid);
+    setTaskReference(newid);
   }
 }
 
@@ -230,7 +230,7 @@ SedParameterEstimationResultPlot::hasRequiredAttributes() const
 {
   bool allPresent = SedPlot::hasRequiredAttributes();
 
-  if (isSetTaskRef() == false)
+  if (isSetTaskReference() == false)
   {
     allPresent = false;
   }
@@ -389,9 +389,9 @@ SedParameterEstimationResultPlot::getAttribute(
     return return_value;
   }
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = getTaskRef();
+    value = getTaskReference();
     return_value = LIBSEDML_OPERATION_SUCCESS;
   }
 
@@ -414,9 +414,9 @@ SedParameterEstimationResultPlot::isSetAttribute(const std::string&
 {
   bool value = SedPlot::isSetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = isSetTaskRef();
+    value = isSetTaskReference();
   }
 
   return value;
@@ -524,9 +524,9 @@ SedParameterEstimationResultPlot::setAttribute(
 {
   int return_value = SedPlot::setAttribute(attributeName, value);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    return_value = setTaskRef(value);
+    return_value = setTaskReference(value);
   }
 
   return return_value;
@@ -548,9 +548,9 @@ SedParameterEstimationResultPlot::unsetAttribute(const std::string&
 {
   int value = SedPlot::unsetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = unsetTaskRef();
+    value = unsetTaskReference();
   }
 
   return value;
@@ -591,7 +591,7 @@ SedParameterEstimationResultPlot::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QU
 {
   SedPlot::addExpectedAttributes(attributes);
 
-  attributes.add("taskRef");
+  attributes.add("taskReference");
 }
 
 /** @endcond */
@@ -636,29 +636,29 @@ SedParameterEstimationResultPlot::readAttributes(
   }
 
   // 
-  // taskRef SIdRef (use = "required" )
+  // taskReference SIdRef (use = "required" )
   // 
 
-  assigned = attributes.readInto("taskRef", mTaskRef);
+  assigned = attributes.readInto("taskReference", mTaskReference);
 
   if (assigned == true)
   {
-    if (mTaskRef.empty() == true)
+    if (mTaskReference.empty() == true)
     {
-      logEmptyString(mTaskRef, level, version,
+      logEmptyString(mTaskReference, level, version,
         "<SedParameterEstimationResultPlot>");
     }
-    else if (SyntaxChecker::isValidSBMLSId(mTaskRef) == false)
+    else if (SyntaxChecker::isValidSBMLSId(mTaskReference) == false)
     {
-      std::string msg = "The taskRef attribute on the <" + getElementName() +
+      std::string msg = "The taskReference attribute on the <" + getElementName() +
         ">";
       if (isSetId())
       {
         msg += " with id '" + getId() + "'";
       }
 
-      msg += " is '" + mTaskRef + "', which does not conform to the syntax.";
-      logError(SedmlParameterEstimationResultPlotTaskRefMustBeTask, level,
+      msg += " is '" + mTaskReference + "', which does not conform to the syntax.";
+      logError(SedmlParameterEstimationResultPlotTaskReferenceMustBeTask, level,
         version, msg, getLine(), getColumn());
     }
   }
@@ -666,7 +666,7 @@ SedParameterEstimationResultPlot::readAttributes(
   {
     if (log)
     {
-      std::string message = "Sedml attribute 'taskRef' is missing from the "
+      std::string message = "Sedml attribute 'taskReference' is missing from the "
         "<SedParameterEstimationResultPlot> element.";
       log->logError(SedmlParameterEstimationResultPlotAllowedAttributes, level,
         version, message, getLine(), getColumn());
@@ -689,9 +689,9 @@ SedParameterEstimationResultPlot::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIE
 {
   SedPlot::writeAttributes(stream);
 
-  if (isSetTaskRef() == true)
+  if (isSetTaskReference() == true)
   {
-    stream.writeAttribute("taskRef", getPrefix(), mTaskRef);
+    stream.writeAttribute("taskReference", getPrefix(), mTaskReference);
   }
 }
 
@@ -752,12 +752,12 @@ SedParameterEstimationResultPlot_free(SedParameterEstimationResultPlot_t*
 
 
 /*
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  */
 LIBSEDML_EXTERN
 char *
-SedParameterEstimationResultPlot_getTaskRef(const
+SedParameterEstimationResultPlot_getTaskReference(const
   SedParameterEstimationResultPlot_t * sperp)
 {
   if (sperp == NULL)
@@ -765,50 +765,50 @@ SedParameterEstimationResultPlot_getTaskRef(const
     return NULL;
   }
 
-  return sperp->getTaskRef().empty() ? NULL :
-    safe_strdup(sperp->getTaskRef().c_str());
+  return sperp->getTaskReference().empty() ? NULL :
+    safe_strdup(sperp->getTaskReference().c_str());
 }
 
 
 /*
  * Predicate returning @c 1 (true) if this SedParameterEstimationResultPlot_t's
- * "taskRef" attribute is set.
+ * "taskReference" attribute is set.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_isSetTaskRef(const
+SedParameterEstimationResultPlot_isSetTaskReference(const
   SedParameterEstimationResultPlot_t * sperp)
 {
-  return (sperp != NULL) ? static_cast<int>(sperp->isSetTaskRef()) : 0;
+  return (sperp != NULL) ? static_cast<int>(sperp->isSetTaskReference()) : 0;
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_setTaskRef(
+SedParameterEstimationResultPlot_setTaskReference(
                                             SedParameterEstimationResultPlot_t
                                               * sperp,
-                                            const char * taskRef)
+                                            const char * taskReference)
 {
-  return (sperp != NULL) ? sperp->setTaskRef(taskRef) :
+  return (sperp != NULL) ? sperp->setTaskReference(taskReference) :
     LIBSEDML_INVALID_OBJECT;
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_unsetTaskRef(SedParameterEstimationResultPlot_t
+SedParameterEstimationResultPlot_unsetTaskReference(SedParameterEstimationResultPlot_t
   * sperp)
 {
-  return (sperp != NULL) ? sperp->unsetTaskRef() : LIBSEDML_INVALID_OBJECT;
+  return (sperp != NULL) ? sperp->unsetTaskReference() : LIBSEDML_INVALID_OBJECT;
 }
 
 

--- a/src/sedml/SedParameterEstimationResultPlot.h
+++ b/src/sedml/SedParameterEstimationResultPlot.h
@@ -64,7 +64,7 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mTaskRef;
+  std::string mTaskReference;
 
   /** @endcond */
 
@@ -133,48 +133,48 @@ public:
 
 
   /**
-   * Returns the value of the "taskRef" attribute of this
+   * Returns the value of the "taskReference" attribute of this
    * SedParameterEstimationResultPlot.
    *
-   * @return the value of the "taskRef" attribute of this
+   * @return the value of the "taskReference" attribute of this
    * SedParameterEstimationResultPlot as a string.
    */
-  const std::string& getTaskRef() const;
+  const std::string& getTaskReference() const;
 
 
   /**
    * Predicate returning @c true if this SedParameterEstimationResultPlot's
-   * "taskRef" attribute is set.
+   * "taskReference" attribute is set.
    *
-   * @return @c true if this SedParameterEstimationResultPlot's "taskRef"
+   * @return @c true if this SedParameterEstimationResultPlot's "taskReference"
    * attribute has been set, otherwise @c false is returned.
    */
-  bool isSetTaskRef() const;
+  bool isSetTaskReference() const;
 
 
   /**
-   * Sets the value of the "taskRef" attribute of this
+   * Sets the value of the "taskReference" attribute of this
    * SedParameterEstimationResultPlot.
    *
-   * @param taskRef std::string& value of the "taskRef" attribute to be set.
+   * @param taskReference std::string& value of the "taskReference" attribute to be set.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
    * OperationReturnValues_t}
    */
-  int setTaskRef(const std::string& taskRef);
+  int setTaskReference(const std::string& taskReference);
 
 
   /**
-   * Unsets the value of the "taskRef" attribute of this
+   * Unsets the value of the "taskReference" attribute of this
    * SedParameterEstimationResultPlot.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
    */
-  int unsetTaskRef();
+  int unsetTaskReference();
 
 
   /**
@@ -223,7 +223,7 @@ public:
    *
    * @note The required attributes for the SedParameterEstimationResultPlot
    * object are:
-   * @li "taskRef"
+   * @li "taskReference"
    */
   virtual bool hasRequiredAttributes() const;
 
@@ -647,13 +647,13 @@ SedParameterEstimationResultPlot_free(SedParameterEstimationResultPlot_t*
 
 
 /**
- * Returns the value of the "taskRef" attribute of this
+ * Returns the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  *
- * @param sperp the SedParameterEstimationResultPlot_t structure whose taskRef
+ * @param sperp the SedParameterEstimationResultPlot_t structure whose taskReference
  * is sought.
  *
- * @return the value of the "taskRef" attribute of this
+ * @return the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t as a pointer to a string.
  *
  * @copydetails doc_returned_owned_char
@@ -662,34 +662,34 @@ SedParameterEstimationResultPlot_free(SedParameterEstimationResultPlot_t*
  */
 LIBSEDML_EXTERN
 char *
-SedParameterEstimationResultPlot_getTaskRef(const
+SedParameterEstimationResultPlot_getTaskReference(const
   SedParameterEstimationResultPlot_t * sperp);
 
 
 /**
  * Predicate returning @c 1 (true) if this SedParameterEstimationResultPlot_t's
- * "taskRef" attribute is set.
+ * "taskReference" attribute is set.
  *
  * @param sperp the SedParameterEstimationResultPlot_t structure.
  *
- * @return @c 1 (true) if this SedParameterEstimationResultPlot_t's "taskRef"
+ * @return @c 1 (true) if this SedParameterEstimationResultPlot_t's "taskReference"
  * attribute has been set, otherwise @c 0 (false) is returned.
  *
  * @memberof SedParameterEstimationResultPlot_t
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_isSetTaskRef(const
+SedParameterEstimationResultPlot_isSetTaskReference(const
   SedParameterEstimationResultPlot_t * sperp);
 
 
 /**
- * Sets the value of the "taskRef" attribute of this
+ * Sets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  *
  * @param sperp the SedParameterEstimationResultPlot_t structure.
  *
- * @param taskRef const char * value of the "taskRef" attribute to be set.
+ * @param taskReference const char * value of the "taskReference" attribute to be set.
  *
  * @copydetails doc_returns_success_code
  * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
@@ -701,14 +701,14 @@ SedParameterEstimationResultPlot_isSetTaskRef(const
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_setTaskRef(
+SedParameterEstimationResultPlot_setTaskReference(
                                             SedParameterEstimationResultPlot_t
                                               * sperp,
-                                            const char * taskRef);
+                                            const char * taskReference);
 
 
 /**
- * Unsets the value of the "taskRef" attribute of this
+ * Unsets the value of the "taskReference" attribute of this
  * SedParameterEstimationResultPlot_t.
  *
  * @param sperp the SedParameterEstimationResultPlot_t structure.
@@ -722,7 +722,7 @@ SedParameterEstimationResultPlot_setTaskRef(
  */
 LIBSEDML_EXTERN
 int
-SedParameterEstimationResultPlot_unsetTaskRef(SedParameterEstimationResultPlot_t
+SedParameterEstimationResultPlot_unsetTaskReference(SedParameterEstimationResultPlot_t
   * sperp);
 
 
@@ -739,7 +739,7 @@ SedParameterEstimationResultPlot_unsetTaskRef(SedParameterEstimationResultPlot_t
  *
  * @note The required attributes for the SedParameterEstimationResultPlot_t
  * object are:
- * @li "taskRef"
+ * @li "taskReference"
  *
  * @memberof SedParameterEstimationResultPlot_t
  */

--- a/src/sedml/SedWaterfallPlot.cpp
+++ b/src/sedml/SedWaterfallPlot.cpp
@@ -53,7 +53,7 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
  */
 SedWaterfallPlot::SedWaterfallPlot(unsigned int level, unsigned int version)
   : SedPlot(level, version)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setSedNamespacesAndOwn(new SedNamespaces(level, version));
 }
@@ -65,7 +65,7 @@ SedWaterfallPlot::SedWaterfallPlot(unsigned int level, unsigned int version)
  */
 SedWaterfallPlot::SedWaterfallPlot(SedNamespaces *sedmlns)
   : SedPlot(sedmlns)
-  , mTaskRef ("")
+  , mTaskReference ("")
 {
   setElementNamespace(sedmlns->getURI());
 }
@@ -76,7 +76,7 @@ SedWaterfallPlot::SedWaterfallPlot(SedNamespaces *sedmlns)
  */
 SedWaterfallPlot::SedWaterfallPlot(const SedWaterfallPlot& orig)
   : SedPlot( orig )
-  , mTaskRef ( orig.mTaskRef )
+  , mTaskReference ( orig.mTaskReference )
 {
 }
 
@@ -90,7 +90,7 @@ SedWaterfallPlot::operator=(const SedWaterfallPlot& rhs)
   if (&rhs != this)
   {
     SedPlot::operator=(rhs);
-    mTaskRef = rhs.mTaskRef;
+    mTaskReference = rhs.mTaskReference;
   }
 
   return *this;
@@ -116,53 +116,53 @@ SedWaterfallPlot::~SedWaterfallPlot()
 
 
 /*
- * Returns the value of the "taskRef" attribute of this SedWaterfallPlot.
+ * Returns the value of the "taskReference" attribute of this SedWaterfallPlot.
  */
 const std::string&
-SedWaterfallPlot::getTaskRef() const
+SedWaterfallPlot::getTaskReference() const
 {
-  return mTaskRef;
+  return mTaskReference;
 }
 
 
 /*
- * Predicate returning @c true if this SedWaterfallPlot's "taskRef" attribute
+ * Predicate returning @c true if this SedWaterfallPlot's "taskReference" attribute
  * is set.
  */
 bool
-SedWaterfallPlot::isSetTaskRef() const
+SedWaterfallPlot::isSetTaskReference() const
 {
-  return (mTaskRef.empty() == false);
+  return (mTaskReference.empty() == false);
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this SedWaterfallPlot.
+ * Sets the value of the "taskReference" attribute of this SedWaterfallPlot.
  */
 int
-SedWaterfallPlot::setTaskRef(const std::string& taskRef)
+SedWaterfallPlot::setTaskReference(const std::string& taskReference)
 {
-  if (!(SyntaxChecker::isValidInternalSId(taskRef)))
+  if (!(SyntaxChecker::isValidInternalSId(taskReference)))
   {
     return LIBSEDML_INVALID_ATTRIBUTE_VALUE;
   }
   else
   {
-    mTaskRef = taskRef;
+    mTaskReference = taskReference;
     return LIBSEDML_OPERATION_SUCCESS;
   }
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this SedWaterfallPlot.
+ * Unsets the value of the "taskReference" attribute of this SedWaterfallPlot.
  */
 int
-SedWaterfallPlot::unsetTaskRef()
+SedWaterfallPlot::unsetTaskReference()
 {
-  mTaskRef.erase();
+  mTaskReference.erase();
 
-  if (mTaskRef.empty() == true)
+  if (mTaskReference.empty() == true)
   {
     return LIBSEDML_OPERATION_SUCCESS;
   }
@@ -180,9 +180,9 @@ void
 SedWaterfallPlot::renameSIdRefs(const std::string& oldid,
                                 const std::string& newid)
 {
-  if (isSetTaskRef() && mTaskRef == oldid)
+  if (isSetTaskReference() && mTaskReference == oldid)
   {
-    setTaskRef(newid);
+    setTaskReference(newid);
   }
 }
 
@@ -217,7 +217,7 @@ SedWaterfallPlot::hasRequiredAttributes() const
 {
   bool allPresent = SedPlot::hasRequiredAttributes();
 
-  if (isSetTaskRef() == false)
+  if (isSetTaskReference() == false)
   {
     allPresent = false;
   }
@@ -361,9 +361,9 @@ SedWaterfallPlot::getAttribute(const std::string& attributeName,
     return return_value;
   }
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = getTaskRef();
+    value = getTaskReference();
     return_value = LIBSEDML_OPERATION_SUCCESS;
   }
 
@@ -385,9 +385,9 @@ SedWaterfallPlot::isSetAttribute(const std::string& attributeName) const
 {
   bool value = SedPlot::isSetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = isSetTaskRef();
+    value = isSetTaskReference();
   }
 
   return value;
@@ -477,9 +477,9 @@ SedWaterfallPlot::setAttribute(const std::string& attributeName,
 {
   int return_value = SedPlot::setAttribute(attributeName, value);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    return_value = setTaskRef(value);
+    return_value = setTaskReference(value);
   }
 
   return return_value;
@@ -499,9 +499,9 @@ SedWaterfallPlot::unsetAttribute(const std::string& attributeName)
 {
   int value = SedPlot::unsetAttribute(attributeName);
 
-  if (attributeName == "taskRef")
+  if (attributeName == "taskReference")
   {
-    value = unsetTaskRef();
+    value = unsetTaskReference();
   }
 
   return value;
@@ -542,7 +542,7 @@ SedWaterfallPlot::addExpectedAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedPlot::addExpectedAttributes(attributes);
 
-  attributes.add("taskRef");
+  attributes.add("taskReference");
 }
 
 /** @endcond */
@@ -586,28 +586,28 @@ SedWaterfallPlot::readAttributes(
   }
 
   // 
-  // taskRef SIdRef (use = "required" )
+  // taskReference SIdRef (use = "required" )
   // 
 
-  assigned = attributes.readInto("taskRef", mTaskRef);
+  assigned = attributes.readInto("taskReference", mTaskReference);
 
   if (assigned == true)
   {
-    if (mTaskRef.empty() == true)
+    if (mTaskReference.empty() == true)
     {
-      logEmptyString(mTaskRef, level, version, "<SedWaterfallPlot>");
+      logEmptyString(mTaskReference, level, version, "<SedWaterfallPlot>");
     }
-    else if (SyntaxChecker::isValidSBMLSId(mTaskRef) == false)
+    else if (SyntaxChecker::isValidSBMLSId(mTaskReference) == false)
     {
-      std::string msg = "The taskRef attribute on the <" + getElementName() +
+      std::string msg = "The taskReference attribute on the <" + getElementName() +
         ">";
       if (isSetId())
       {
         msg += " with id '" + getId() + "'";
       }
 
-      msg += " is '" + mTaskRef + "', which does not conform to the syntax.";
-      logError(SedmlWaterfallPlotTaskRefMustBeTask, level, version, msg,
+      msg += " is '" + mTaskReference + "', which does not conform to the syntax.";
+      logError(SedmlWaterfallPlotTaskReferenceMustBeTask, level, version, msg,
         getLine(), getColumn());
     }
   }
@@ -615,7 +615,7 @@ SedWaterfallPlot::readAttributes(
   {
     if (log)
     {
-      std::string message = "Sedml attribute 'taskRef' is missing from the "
+      std::string message = "Sedml attribute 'taskReference' is missing from the "
         "<SedWaterfallPlot> element.";
       log->logError(SedmlWaterfallPlotAllowedAttributes, level, version,
         message, getLine(), getColumn());
@@ -638,9 +638,9 @@ SedWaterfallPlot::writeAttributes(LIBSBML_CPP_NAMESPACE_QUALIFIER
 {
   SedPlot::writeAttributes(stream);
 
-  if (isSetTaskRef() == true)
+  if (isSetTaskReference() == true)
   {
-    stream.writeAttribute("taskRef", getPrefix(), mTaskRef);
+    stream.writeAttribute("taskReference", getPrefix(), mTaskReference);
   }
 }
 
@@ -697,53 +697,53 @@ SedWaterfallPlot_free(SedWaterfallPlot_t* swp)
 
 
 /*
- * Returns the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Returns the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  */
 LIBSEDML_EXTERN
 char *
-SedWaterfallPlot_getTaskRef(const SedWaterfallPlot_t * swp)
+SedWaterfallPlot_getTaskReference(const SedWaterfallPlot_t * swp)
 {
   if (swp == NULL)
   {
     return NULL;
   }
 
-  return swp->getTaskRef().empty() ? NULL :
-    safe_strdup(swp->getTaskRef().c_str());
+  return swp->getTaskReference().empty() ? NULL :
+    safe_strdup(swp->getTaskReference().c_str());
 }
 
 
 /*
- * Predicate returning @c 1 (true) if this SedWaterfallPlot_t's "taskRef"
+ * Predicate returning @c 1 (true) if this SedWaterfallPlot_t's "taskReference"
  * attribute is set.
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_isSetTaskRef(const SedWaterfallPlot_t * swp)
+SedWaterfallPlot_isSetTaskReference(const SedWaterfallPlot_t * swp)
 {
-  return (swp != NULL) ? static_cast<int>(swp->isSetTaskRef()) : 0;
+  return (swp != NULL) ? static_cast<int>(swp->isSetTaskReference()) : 0;
 }
 
 
 /*
- * Sets the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Sets the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_setTaskRef(SedWaterfallPlot_t * swp, const char * taskRef)
+SedWaterfallPlot_setTaskReference(SedWaterfallPlot_t * swp, const char * taskReference)
 {
-  return (swp != NULL) ? swp->setTaskRef(taskRef) : LIBSEDML_INVALID_OBJECT;
+  return (swp != NULL) ? swp->setTaskReference(taskReference) : LIBSEDML_INVALID_OBJECT;
 }
 
 
 /*
- * Unsets the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Unsets the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_unsetTaskRef(SedWaterfallPlot_t * swp)
+SedWaterfallPlot_unsetTaskReference(SedWaterfallPlot_t * swp)
 {
-  return (swp != NULL) ? swp->unsetTaskRef() : LIBSEDML_INVALID_OBJECT;
+  return (swp != NULL) ? swp->unsetTaskReference() : LIBSEDML_INVALID_OBJECT;
 }
 
 

--- a/src/sedml/SedWaterfallPlot.h
+++ b/src/sedml/SedWaterfallPlot.h
@@ -63,7 +63,7 @@ protected:
 
   /** @cond doxygenLibSEDMLInternal */
 
-  std::string mTaskRef;
+  std::string mTaskReference;
 
   /** @endcond */
 
@@ -128,45 +128,45 @@ public:
 
 
   /**
-   * Returns the value of the "taskRef" attribute of this SedWaterfallPlot.
+   * Returns the value of the "taskReference" attribute of this SedWaterfallPlot.
    *
-   * @return the value of the "taskRef" attribute of this SedWaterfallPlot as a
+   * @return the value of the "taskReference" attribute of this SedWaterfallPlot as a
    * string.
    */
-  const std::string& getTaskRef() const;
+  const std::string& getTaskReference() const;
 
 
   /**
-   * Predicate returning @c true if this SedWaterfallPlot's "taskRef" attribute
+   * Predicate returning @c true if this SedWaterfallPlot's "taskReference" attribute
    * is set.
    *
-   * @return @c true if this SedWaterfallPlot's "taskRef" attribute has been
+   * @return @c true if this SedWaterfallPlot's "taskReference" attribute has been
    * set, otherwise @c false is returned.
    */
-  bool isSetTaskRef() const;
+  bool isSetTaskReference() const;
 
 
   /**
-   * Sets the value of the "taskRef" attribute of this SedWaterfallPlot.
+   * Sets the value of the "taskReference" attribute of this SedWaterfallPlot.
    *
-   * @param taskRef std::string& value of the "taskRef" attribute to be set.
+   * @param taskReference std::string& value of the "taskReference" attribute to be set.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_INVALID_ATTRIBUTE_VALUE,
    * OperationReturnValues_t}
    */
-  int setTaskRef(const std::string& taskRef);
+  int setTaskReference(const std::string& taskReference);
 
 
   /**
-   * Unsets the value of the "taskRef" attribute of this SedWaterfallPlot.
+   * Unsets the value of the "taskReference" attribute of this SedWaterfallPlot.
    *
    * @copydetails doc_returns_success_code
    * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
    * @li @sedmlconstant{LIBSEDML_OPERATION_FAILED, OperationReturnValues_t}
    */
-  int unsetTaskRef();
+  int unsetTaskReference();
 
 
   /**
@@ -210,7 +210,7 @@ public:
    *
    *
    * @note The required attributes for the SedWaterfallPlot object are:
-   * @li "taskRef"
+   * @li "taskReference"
    */
   virtual bool hasRequiredAttributes() const;
 
@@ -620,11 +620,11 @@ SedWaterfallPlot_free(SedWaterfallPlot_t* swp);
 
 
 /**
- * Returns the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Returns the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  *
- * @param swp the SedWaterfallPlot_t structure whose taskRef is sought.
+ * @param swp the SedWaterfallPlot_t structure whose taskReference is sought.
  *
- * @return the value of the "taskRef" attribute of this SedWaterfallPlot_t as a
+ * @return the value of the "taskReference" attribute of this SedWaterfallPlot_t as a
  * pointer to a string.
  *
  * @copydetails doc_returned_owned_char
@@ -633,31 +633,31 @@ SedWaterfallPlot_free(SedWaterfallPlot_t* swp);
  */
 LIBSEDML_EXTERN
 char *
-SedWaterfallPlot_getTaskRef(const SedWaterfallPlot_t * swp);
+SedWaterfallPlot_getTaskReference(const SedWaterfallPlot_t * swp);
 
 
 /**
- * Predicate returning @c 1 (true) if this SedWaterfallPlot_t's "taskRef"
+ * Predicate returning @c 1 (true) if this SedWaterfallPlot_t's "taskReference"
  * attribute is set.
  *
  * @param swp the SedWaterfallPlot_t structure.
  *
- * @return @c 1 (true) if this SedWaterfallPlot_t's "taskRef" attribute has
+ * @return @c 1 (true) if this SedWaterfallPlot_t's "taskReference" attribute has
  * been set, otherwise @c 0 (false) is returned.
  *
  * @memberof SedWaterfallPlot_t
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_isSetTaskRef(const SedWaterfallPlot_t * swp);
+SedWaterfallPlot_isSetTaskReference(const SedWaterfallPlot_t * swp);
 
 
 /**
- * Sets the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Sets the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  *
  * @param swp the SedWaterfallPlot_t structure.
  *
- * @param taskRef const char * value of the "taskRef" attribute to be set.
+ * @param taskReference const char * value of the "taskReference" attribute to be set.
  *
  * @copydetails doc_returns_success_code
  * @li @sedmlconstant{LIBSEDML_OPERATION_SUCCESS, OperationReturnValues_t}
@@ -669,11 +669,11 @@ SedWaterfallPlot_isSetTaskRef(const SedWaterfallPlot_t * swp);
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_setTaskRef(SedWaterfallPlot_t * swp, const char * taskRef);
+SedWaterfallPlot_setTaskReference(SedWaterfallPlot_t * swp, const char * taskReference);
 
 
 /**
- * Unsets the value of the "taskRef" attribute of this SedWaterfallPlot_t.
+ * Unsets the value of the "taskReference" attribute of this SedWaterfallPlot_t.
  *
  * @param swp the SedWaterfallPlot_t structure.
  *
@@ -686,7 +686,7 @@ SedWaterfallPlot_setTaskRef(SedWaterfallPlot_t * swp, const char * taskRef);
  */
 LIBSEDML_EXTERN
 int
-SedWaterfallPlot_unsetTaskRef(SedWaterfallPlot_t * swp);
+SedWaterfallPlot_unsetTaskReference(SedWaterfallPlot_t * swp);
 
 
 /**
@@ -700,7 +700,7 @@ SedWaterfallPlot_unsetTaskRef(SedWaterfallPlot_t * swp);
  *
  *
  * @note The required attributes for the SedWaterfallPlot_t object are:
- * @li "taskRef"
+ * @li "taskReference"
  *
  * @memberof SedWaterfallPlot_t
  */


### PR DESCRIPTION
In a followup to https://github.com/SED-ML/sed-ml/issues/187: we should be consistent and not have 'taskRef' in one place and 'taskReference' in another.