### PR TITLE
Another catch:  'lin' should be 'linear' for ScaleType.

### DIFF
--- a/dev/sedml.xml
+++ b/dev/sedml.xml
@@ -96,8 +96,8 @@
             <attribute name="initialTime" required="true" type="double" abstract="false"/>
             <attribute name="outputStartTime" required="true" type="double" abstract="false"/>
             <attribute name="outputEndTime" required="true" type="double" abstract="false"/>
-            <attribute name="numberOfPoints" required="false" type="int" abstract="false"/>
-            <attribute name="numberOfSteps" required="false" type="int" abstract="false"/>
+            <attribute name="numberOfPoints" required="false" type="positive int" abstract="false"/>
+            <attribute name="numberOfSteps" required="false" type="positive int" abstract="false"/>
           </attributes>
         </element>
         <element name="Algorithm" typeCode="SEDML_SIMULATION_ALGORITHM" hasListOf="false" hasChildren="true" hasMath="false" childrenOverwriteElementName="false" baseClass="SedBase" abstract="false" elementName="algorithm" additionalDecls="algorithm_headers.h" additionalDefs="algorithm_code.cpp">
@@ -251,9 +251,9 @@
           <attributes>
             <attribute name="start" required="true" type="double" abstract="false"/>
             <attribute name="end" required="true" type="double" abstract="false"/>
-            <attribute name="numberOfPoints" required="false" type="int" abstract="false"/>
+            <attribute name="numberOfPoints" required="false" type="positive int" abstract="false"/>
             <attribute name="type" required="true" type="string" abstract="false"/>
-            <attribute name="numberOfSteps" required="false" type="int" abstract="false"/>
+            <attribute name="numberOfSteps" required="false" type="positive int" abstract="false"/>
           </attributes>
         </element>
         <element name="VectorRange" typeCode="SEDML_RANGE_VECTORRANGE" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Range" abstract="false" elementName="vectorRange">

--- a/dev/sedml.xml
+++ b/dev/sedml.xml
@@ -461,12 +461,12 @@
         </element>
         <element name="WaterfallPlot" typeCode="SEDML_WATERFALLPLOT" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Plot" abstract="false">
           <attributes>
-            <attribute name="taskRef" required="true" type="SIdRef" element="Task" abstract="false"/>
+            <attribute name="taskReference" required="true" type="SIdRef" element="Task" abstract="false"/>
           </attributes>
         </element>
         <element name="ParameterEstimationReport" typeCode="SEDML_PARAMETERESTIMATIONREPORT" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Output" abstract="false">
           <attributes>
-            <attribute name="taskRef" required="true" type="SIdRef" element="Task" abstract="false"/>
+            <attribute name="taskReference" required="true" type="SIdRef" element="Task" abstract="false"/>
           </attributes>
         </element>
         <element name="Analysis" typeCode="SEDML_SIMULATION_ANALYSIS" hasListOf="false" hasChildren="false" hasMath="false" childrenOverwriteElementName="false" baseClass="Simulation" abstract="false"/>
@@ -540,7 +540,7 @@
         </enum>
         <enum name="ScaleType">
           <enumValues>
-            <enumValue name="SEDML_SCALETYPE_LIN" value="lin"/>
+            <enumValue name="SEDML_SCALETYPE_LIN" value="linear"/>
             <enumValue name="SEDML_SCALETYPE_LOG" value="log"/>
             <enumValue name="SEDML_SCALETYPE_LOG10" value="log10"/>
           </enumValues>

--- a/src/sedml/SedBounds.h
+++ b/src/sedml/SedBounds.h
@@ -53,7 +53,7 @@
  * Level&nbsp;3 Version&nbsp;1 Sedml specification, the following are the
  * allowable values for "scale":
  * <ul>
- * <li> @c "lin", TODO:add description
+ * <li> @c "linear", TODO:add description
  *
  * <li> @c "log", TODO:add description
  *
@@ -184,7 +184,7 @@ public:
    * @copydetails doc_sedbounds_scale
    * @if clike The value is drawn from the enumeration @ref ScaleType_t @endif
    * The possible values returned by this method are:
-   * @li @sbmlconstant{SEDML_SCALETYPE_LIN, ScaleType_t}
+   * @li @sbmlconstant{SEDML_SCALETYPE_LINEAR, ScaleType_t}
    * @li @sbmlconstant{SEDML_SCALETYPE_LOG, ScaleType_t}
    * @li @sbmlconstant{SEDML_SCALETYPE_LOG10, ScaleType_t}
    * @li @sbmlconstant{SEDML_SCALETYPE_INVALID, ScaleType_t}
@@ -199,7 +199,7 @@ public:
    *
    * @copydetails doc_sedbounds_scale
    * The possible values returned by this method are:
-   * @li @c "lin"
+   * @li @c "linear"
    * @li @c "log"
    * @li @c "log10"
    * @li @c "invalid ScaleType value"
@@ -792,7 +792,7 @@ SedBounds_getUpperBound(const SedBounds_t * sb);
  * @copydetails doc_sedbounds_scale
  * @if clike The value is drawn from the enumeration @ref ScaleType_t @endif
  * The possible values returned by this method are:
- * @li @sbmlconstant{SEDML_SCALETYPE_LIN, ScaleType_t}
+ * @li @sbmlconstant{SEDML_SCALETYPE_LINEAR, ScaleType_t}
  * @li @sbmlconstant{SEDML_SCALETYPE_LOG, ScaleType_t}
  * @li @sbmlconstant{SEDML_SCALETYPE_LOG10, ScaleType_t}
  * @li @sbmlconstant{SEDML_SCALETYPE_INVALID, ScaleType_t}
@@ -817,7 +817,7 @@ SedBounds_getScale(const SedBounds_t * sb);
  *
  * @copydetails doc_sedbounds_scale
  * The possible values returned by this method are:
- * @li @c "lin"
+ * @li @c "linear"
  * @li @c "log"
  * @li @c "log10"
  * @li @c "invalid ScaleType value"

--- a/src/sedml/common/SedmlEnumerations.cpp
+++ b/src/sedml/common/SedmlEnumerations.cpp
@@ -669,7 +669,7 @@ ExperimentType_isValidString(const char* code)
 static
 const char* SEDML_SCALE_TYPE_STRINGS[] =
 {
-  "lin"
+  "linear"
 , "log"
 , "log10"
 , "invalid ScaleType value"
@@ -683,7 +683,7 @@ LIBSEDML_EXTERN
 const char*
 ScaleType_toString(ScaleType_t st)
 {
-  int min = SEDML_SCALETYPE_LIN;
+  int min = SEDML_SCALETYPE_LINEAR;
   int max = SEDML_SCALETYPE_INVALID;
 
   if (st < min || st > max)
@@ -728,7 +728,7 @@ LIBSEDML_EXTERN
 int
 ScaleType_isValid(ScaleType_t st)
 {
-  int min = SEDML_SCALETYPE_LIN;
+  int min = SEDML_SCALETYPE_LINEAR;
   int max = SEDML_SCALETYPE_INVALID;
 
   if (st < min || st >= max)

--- a/src/sedml/common/SedmlEnumerations.h
+++ b/src/sedml/common/SedmlEnumerations.h
@@ -878,7 +878,7 @@ ExperimentType_isValidString(const char* code);
  */
 typedef enum
 {
-  SEDML_SCALETYPE_LIN           /*!< The sedml scaletype is @c "lin". */
+  SEDML_SCALETYPE_LINEAR           /*!< The sedml scaletype is @c "linear". */
 , SEDML_SCALETYPE_LOG           /*!< The sedml scaletype is @c "log". */
 , SEDML_SCALETYPE_LOG10         /*!< The sedml scaletype is @c "log10". */
 , SEDML_SCALETYPE_INVALID       /*!< Invalid ScaleType value. */
@@ -891,7 +891,7 @@ typedef enum
  * @param st the #ScaleType_t enumeration value to convert.
  *
  * @return A string corresponding to the given type:
- * "lin",
+ * "linear",
  * "log",
  * "log10",
  * "invalid ScaleType value",
@@ -919,8 +919,8 @@ ScaleType_toString(ScaleType_t st);
  * @return the corresponding #ScaleType_t or
  * @sbmlconstant{SEDML_SCALETYPE_INVALID, ScaleType_t} if no match is found.
  *
- * @note The matching is case-sensitive: "lin" will return
- * @sbmlconstant{SEDML_SCALETYPE_LIN, ScaleType_t}, but "Lin" will return
+ * @note The matching is case-sensitive: "linear" will return
+ * @sbmlconstant{SEDML_SCALETYPE_LINEAR, ScaleType_t}, but "Linear" will return
  * @sbmlconstant{SEDML_SCALETYPE_INVALID, ScaleType_t}.
  *
  * @if conly
@@ -939,7 +939,7 @@ ScaleType_fromString(const char* code);
  * @param st the #ScaleType_t enumeration to query.
  *
  * @return @c 1 (true) if the #ScaleType_t is
- * @sbmlconstant{SEDML_SCALETYPE_LIN, ScaleType_t},
+ * @sbmlconstant{SEDML_SCALETYPE_LINEAR, ScaleType_t},
  * @sbmlconstant{SEDML_SCALETYPE_LOG, ScaleType_t}, or
  * @sbmlconstant{SEDML_SCALETYPE_LOG10, ScaleType_t};
  * @c 0 (false) otherwise (including @sbmlconstant{SEDML_SCALETYPE_INVALID,
@@ -961,14 +961,14 @@ ScaleType_isValid(ScaleType_t st);
  * @param code the string to query.
  *
  * @return @c 1 (true) if the string is
- * "lin",
+ * "linear",
  * "log",
  * "log10", or
  * "invalid ScaleType value";
  * @c 0 (false) otherwise.
  *
- * @note The matching is case-sensitive: "lin" will return @c 1 (true), but
- * "Lin" will return @c 0 (false).
+ * @note The matching is case-sensitive: "linear" will return @c 1 (true), but
+ * "Linear" will return @c 0 (false).
  *
  * @if conly
  * @memberof Sedml_t


### PR DESCRIPTION
This is from an enum for the new Bounds object.  Changed to match linear/log/log10 for other attributes (such as axis).