### PR TITLE
Two new features to facilitate l1v4 use.

### DIFF
--- a/src/sedml/SedAbstractCurve.cpp
+++ b/src/sedml/SedAbstractCurve.cpp
@@ -37,6 +37,7 @@
 
 #include <sedml/SedCurve.h>
 #include <sedml/SedShadedArea.h>
+#include <sedml/SedPlot.h>
 
 
 using namespace std;
@@ -157,7 +158,40 @@ SedAbstractCurve::~SedAbstractCurve()
 bool
 SedAbstractCurve::getLogX() const
 {
-  return mLogX;
+    if (getVersion() < 4)
+    {
+        return mLogX;
+    }
+    if (isSetLogX())
+    {
+        return mLogX;
+    }
+    const SedBase* parent = getParentSedObject();
+    if (parent) 
+    {
+        parent = parent->getParentSedObject();
+    }
+    if (parent)
+    {
+        if (parent->getTypeCode() == SEDML_OUTPUT_PLOT2D || 
+            parent->getTypeCode() == SEDML_OUTPUT_PLOT3D)
+        {
+            const SedPlot* plot = static_cast<const SedPlot*>(parent);
+            if (plot)
+            {
+                const SedAxis* axis = plot->getXAxis();
+                if (axis && axis->isSetType())
+                {
+                    return axis->getType() == SEDML_AXISTYPE_LOG10;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    return mLogX;
 }
 
 

--- a/src/sedml/SedBase.cpp
+++ b/src/sedml/SedBase.cpp
@@ -1934,11 +1934,23 @@ SedBase::setSedNamespaces(SedNamespaces * sedmlns)
 void
 SedBase::setSedNamespacesAndOwn(SedNamespaces * sedmlns)
 {
-  delete mSedNamespaces;
-  mSedNamespaces = sedmlns;
+    libsbml::XMLNamespaces* names = mSedNamespaces->getNamespaces();
+    libsbml::XMLNamespaces* newnames = sedmlns->getNamespaces();
+    for (int name = 0; name < names->getNumNamespaces(); name++)
+    {
+        if (!names->getPrefix(name).empty())
+        {
+            if (!newnames->containsUri(names->getURI(name)))
+            {
+                sedmlns->addNamespace(names->getURI(name), names->getPrefix(name));
+            }
+        }
+    }
+    delete mSedNamespaces;
+    mSedNamespaces = sedmlns;
 
-  if(sedmlns != NULL)
-    setElementNamespace(sedmlns->getURI());
+    if (sedmlns != NULL)
+        setElementNamespace(sedmlns->getURI());
 }
 
 

--- a/src/sedml/SedBase.cpp
+++ b/src/sedml/SedBase.cpp
@@ -1934,8 +1934,8 @@ SedBase::setSedNamespaces(SedNamespaces * sedmlns)
 void
 SedBase::setSedNamespacesAndOwn(SedNamespaces * sedmlns)
 {
-    libsbml::XMLNamespaces* names = mSedNamespaces->getNamespaces();
-    libsbml::XMLNamespaces* newnames = sedmlns->getNamespaces();
+    XMLNamespaces* names = mSedNamespaces->getNamespaces();
+    XMLNamespaces* newnames = sedmlns->getNamespaces();
     for (int name = 0; name < names->getNumNamespaces(); name++)
     {
         if (!names->getPrefix(name).empty())

--- a/src/sedml/SedCurve.cpp
+++ b/src/sedml/SedCurve.cpp
@@ -33,6 +33,7 @@
  */
 #include <sedml/SedCurve.h>
 #include <sbml/xml/XMLInputStream.h>
+#include <sedml/SedPlot2D.h>
 
 
 using namespace std;
@@ -147,6 +148,42 @@ SedCurve::~SedCurve()
 bool
 SedCurve::getLogY() const
 {
+  if (getVersion() < 4)
+  {
+      return mLogY;
+  }
+  if (isSetLogY())
+  {
+      return mLogY;
+  }
+  const SedBase* parent = getParentSedObject();
+  if (parent)
+  {
+      parent = parent->getParentSedObject();
+  }
+  if (parent)
+  {
+      if (parent->getTypeCode() == SEDML_OUTPUT_PLOT2D)
+      {
+          const SedPlot2D* plot = static_cast<const SedPlot2D*>(parent);
+          if (plot)
+          {
+              const SedAxis* axis = plot->getYAxis();
+              if (getYAxis() == "right")
+              {
+                  axis = plot->getRightYAxis();
+              }
+              if (axis && axis->isSetType())
+              {
+                  return axis->getType() == SEDML_AXISTYPE_LOG10;
+              }
+              else
+              {
+                  return false;
+              }
+          }
+      }
+  }
   return mLogY;
 }
 

--- a/src/sedml/SedSurface.cpp
+++ b/src/sedml/SedSurface.cpp
@@ -34,6 +34,7 @@
 #include <sedml/SedSurface.h>
 #include <sedml/SedListOfSurfaces.h>
 #include <sbml/xml/XMLInputStream.h>
+#include <sedml/SedPlot3D.h>
 
 
 using namespace std;
@@ -233,7 +234,40 @@ SedSurface::getStyle() const
 bool
 SedSurface::getLogX() const
 {
-  return mLogX;
+    if (getVersion() < 4)
+    {
+        return mLogX;
+    }
+    if (isSetLogX())
+    {
+        return mLogX;
+    }
+    const SedBase* parent = getParentSedObject();
+    if (parent)
+    {
+        parent = parent->getParentSedObject();
+    }
+    if (parent)
+    {
+        if (parent->getTypeCode() == SEDML_OUTPUT_PLOT2D ||
+            parent->getTypeCode() == SEDML_OUTPUT_PLOT3D)
+        {
+            const SedPlot* plot = static_cast<const SedPlot*>(parent);
+            if (plot)
+            {
+                const SedAxis* axis = plot->getXAxis();
+                if (axis && axis->isSetType())
+                {
+                    return axis->getType() == SEDML_AXISTYPE_LOG10;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    return mLogX;
 }
 
 
@@ -243,7 +277,40 @@ SedSurface::getLogX() const
 bool
 SedSurface::getLogY() const
 {
-  return mLogY;
+    if (getVersion() < 4)
+    {
+        return mLogY;
+    }
+    if (isSetLogY())
+    {
+        return mLogY;
+    }
+    const SedBase* parent = getParentSedObject();
+    if (parent)
+    {
+        parent = parent->getParentSedObject();
+    }
+    if (parent)
+    {
+        if (parent->getTypeCode() == SEDML_OUTPUT_PLOT2D ||
+            parent->getTypeCode() == SEDML_OUTPUT_PLOT3D)
+        {
+            const SedPlot* plot = static_cast<const SedPlot*>(parent);
+            if (plot)
+            {
+                const SedAxis* axis = plot->getYAxis();
+                if (axis && axis->isSetType())
+                {
+                    return axis->getType() == SEDML_AXISTYPE_LOG10;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    return mLogY;
 }
 
 
@@ -253,7 +320,39 @@ SedSurface::getLogY() const
 bool
 SedSurface::getLogZ() const
 {
-  return mLogZ;
+    if (getVersion() < 4)
+    {
+        return mLogZ;
+    }
+    if (isSetLogZ())
+    {
+        return mLogZ;
+    }
+    const SedBase* parent = getParentSedObject();
+    if (parent)
+    {
+        parent = parent->getParentSedObject();
+    }
+    if (parent)
+    {
+        if (parent->getTypeCode() == SEDML_OUTPUT_PLOT3D)
+        {
+            const SedPlot3D* plot = static_cast<const SedPlot3D*>(parent);
+            if (plot)
+            {
+                const SedAxis* axis = plot->getZAxis();
+                if (axis && axis->isSetType())
+                {
+                    return axis->getType() == SEDML_AXISTYPE_LOG10;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+        }
+    }
+    return mLogZ;
 }
 
 

--- a/tests/TestIssues.cpp
+++ b/tests/TestIssues.cpp
@@ -932,3 +932,45 @@ TEST_CASE("Create Analysis simulation", "[sedml]")
 
 }
 
+TEST_CASE("Don't quash extra namespaces on upleveling", "[sedml]")
+{
+    SedDocument doc(1, 3);
+    doc.getNamespaces()->add("http://test.org/uri", "test");
+    doc.setLevel(4);
+    REQUIRE(doc.getNamespaces()->getNumNamespaces() == 2);
+    CHECK(doc.getNamespaces()->getURI(1) == "http://test.org/uri");
+    CHECK(doc.getNamespaces()->getPrefix(1) == "test");
+
+}
+
+TEST_CASE("Redirect getLog for L1v4, 2d", "[sedml]")
+{
+    std::string fileName = getTestFile("/test-data/logtest.sedml");
+    SedDocument* doc = readSedMLFromFile(fileName.c_str());
+    SedOutput* out = doc->getOutput(0);
+    SedPlot2D* plot = static_cast<SedPlot2D*>(out);
+    REQUIRE(plot);
+    SedCurve* curve = static_cast<SedCurve*>(plot->getCurve(0));
+    REQUIRE(curve);
+    CHECK(curve->getLogX() == true);
+    CHECK(curve->getLogY() == false);
+    curve = static_cast<SedCurve*>(plot->getCurve(1));
+    REQUIRE(curve);
+    CHECK(curve->getLogX() == true);
+    CHECK(curve->getLogY() == true);
+}
+
+TEST_CASE("Redirect getLog for L1v4, 3d", "[sedml]")
+{
+    std::string fileName = getTestFile("/test-data/logtest3d.sedml");
+    SedDocument* doc = readSedMLFromFile(fileName.c_str());
+    SedOutput* out = doc->getOutput(0);
+    SedPlot3D* plot = static_cast<SedPlot3D*>(out);
+    REQUIRE(plot);
+    SedSurface* curve = static_cast<SedSurface*>(plot->getSurface(0));
+    REQUIRE(curve);
+    CHECK(curve->getLogX() == true);
+    CHECK(curve->getLogY() == false);
+    CHECK(curve->getLogZ() == true);
+}
+

--- a/tests/test-data/logtest.sedml
+++ b/tests/test-data/logtest.sedml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:sbml="http://www.sbml.org/sbml/level3/version1/core" level="1" version="4">
+  <listOfModels>
+    <model id="model0" language="urn:sedml:language:sbml.level-3.version-1" source="case_02.xml"/>
+  </listOfModels>
+  <listOfSimulations>
+    <uniformTimeCourse id="sim0" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfSteps="10">
+      <algorithm kisaoID="KISAO:0000019"/>
+    </uniformTimeCourse>
+  </listOfSimulations>
+  <listOfTasks>
+    <task id="task0" modelReference="model0" simulationReference="sim0"/>
+  </listOfTasks>
+  <listOfDataGenerators>
+    <dataGenerator id="plot_0_0_0" name="time">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> time </ci>
+      </math>
+      <listOfVariables>
+        <variable id="time" symbol="urn:sedml:symbol:time" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+    <dataGenerator id="plot_0_0_1" name="S1">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> S1 </ci>
+      </math>
+      <listOfVariables>
+        <variable id="S1" target="/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id=&apos;S1&apos;]" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+    <dataGenerator id="plot_0_1_1" name="S2">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> S2 </ci>
+      </math>
+      <listOfVariables>
+        <variable id="S2" target="/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id=&apos;S2&apos;]" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+  </listOfDataGenerators>
+  <listOfOutputs>
+    <plot2D id="plot_0" name="UniformTimecourse">
+      <xAxis type="log10"/>
+      <yAxis type="linear"/>
+      <rightYAxis type="log10"/>
+      <listOfCurves>
+        <curve id="plot_0__plot_0_0_0__plot_0_0_1" order="2" xDataReference="plot_0_0_0" yDataReference="plot_0_0_1" type="points"/>
+        <curve id="plot_0__plot_0_0_0__plot_0_1_1" order="3" yAxis="right" xDataReference="plot_0_0_0" yDataReference="plot_0_1_1" type="points"/>
+      </listOfCurves>
+    </plot2D>
+  </listOfOutputs>
+</sedML>

--- a/tests/test-data/logtest3d.sedml
+++ b/tests/test-data/logtest3d.sedml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" xmlns:sbml="http://www.sbml.org/sbml/level3/version1/core" level="1" version="4">
+  <listOfModels>
+    <model id="model0" language="urn:sedml:language:sbml.level-3.version-1" source="case_02.xml"/>
+  </listOfModels>
+  <listOfSimulations>
+    <uniformTimeCourse id="sim0" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfSteps="10">
+      <algorithm kisaoID="KISAO:0000019"/>
+    </uniformTimeCourse>
+  </listOfSimulations>
+  <listOfTasks>
+    <task id="task0" modelReference="model0" simulationReference="sim0"/>
+  </listOfTasks>
+  <listOfDataGenerators>
+    <dataGenerator id="plot_0_0_0" name="time">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> time </ci>
+      </math>
+      <listOfVariables>
+        <variable id="time" symbol="urn:sedml:symbol:time" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+    <dataGenerator id="plot_0_0_1" name="S1">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> S1 </ci>
+      </math>
+      <listOfVariables>
+        <variable id="S1" target="/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id=&apos;S1&apos;]" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+    <dataGenerator id="plot_0_0_2" name="S2">
+      <math xmlns="http://www.w3.org/1998/Math/MathML">
+        <ci> S2 </ci>
+      </math>
+      <listOfVariables>
+        <variable id="S2" target="/sbml:sbml/sbml:model/sbml:listOfSpecies/sbml:species[@id=&apos;S2&apos;]" taskReference="task0" modelReference="model0"/>
+      </listOfVariables>
+    </dataGenerator>
+  </listOfDataGenerators>
+  <listOfOutputs>
+    <plot3D id="plot_0" name="UniformTimecourse">
+      <xAxis type="log10"/>
+      <yAxis type="linear"/>
+      <zAxis type="log10"/>
+      <listOfSurfaces>
+        <surface id="plot_0__plot_0_0_0__plot_0_0_1__plot_0_0_2" xDataReference="plot_0_0_0" yDataReference="plot_0_0_1" zDataReference="plot_0_0_2" type="parametricCurve"/>
+      </listOfSurfaces>
+    </plot3D>
+  </listOfOutputs>
+</sedML>


### PR DESCRIPTION
* In an L1v4 model with no 'log*' attributes on curves/surfaces, 'getLog*' now checks with the corresponding axis and returns whether or not that axis is marked log or not.
* When changing the 'version' of a document, any non-SEDML namespaces are copied over to the new set.  This is important because the model namespaces need to be declared somewhere, and often end up on the SedDocument, for lack of anywhere better (i.e. the SBML namespace).

Both of these changes should ease adoption of l1v4.