### PR TITLE
SedElementFilter: make sure that it gets exported on Windows

### DIFF
--- a/src/sedml/SedElementFilter.h
+++ b/src/sedml/SedElementFilter.h
@@ -131,7 +131,7 @@ LIBSEDML_CPP_NAMESPACE_BEGIN
 
 class SedBase;
 
-class LIBSBML_EXTERN SedElementFilter
+class LIBSEDML_EXTERN SedElementFilter
 {
 public:
 


### PR DESCRIPTION
@fbergmann, I can see that you are now using GitHub Actions, so you might want to test both the shared and static versions of libSEDML?