### PR TITLE
Remove the 'dist' target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,8 +331,12 @@ endif()
 #
 # Locate libsbml
 #
-find_package(LIBSBML REQUIRED)
-find_package(LIBNUML REQUIRED)
+if(NOT TARGET libsbml-static)
+   find_package(LIBSBML REQUIRED)
+endif()
+if(NOT TARGET libnuml)
+   find_package(LIBNUML REQUIRED)
+endif()
 
 SET(LIBSEDML_LIBS ${LIBNUML_LIBRARY_NAME} ${LIBSBML_LIBRARY})
 
@@ -387,10 +391,6 @@ if(WITH_ZLIB)
         if(UNIX)
             message(WARNING "The zlib library does not appear to be valid because it is missing certain required symbols. Please check that ${LIBZ_LIBRARY} is the zlib library. For details about the error, please see ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log")
         endif()
-    endif()
-
-    if(NOT EXISTS "${LIBZ_INCLUDE_DIR}/zlib.h")
-        message(FATAL_ERROR "The zlib include directory does not appear to be valid. It should contain the file zlib.h, but it does not.")
     endif()
 
 endif(WITH_ZLIB)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,10 +117,6 @@ set(PACKAGE_CONFIG_DIR "${CMAKE_INSTALL_LIBDIR}/cmake" CACHE PATH
 # src/CMakeLists.txt
 set(PROJECT_VERSION ${LIBSEDML_VERSION})
 
-# add make dist and make check target as they are already familiar for
-# everyone using the gnumake build
-# add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
-
 ###############################################################################
 #
 # The next lines configure the parameters for packaging the binaries.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,7 +119,7 @@ set(PROJECT_VERSION ${LIBSEDML_VERSION})
 
 # add make dist and make check target as they are already familiar for
 # everyone using the gnumake build
-add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
+# add_custom_target(dist COMMAND ${CMAKE_MAKE_PROGRAM} package_source)
 
 ###############################################################################
 #


### PR DESCRIPTION
'dist' is a holdover from gnumake days, and is no longer used in modern CMake files.  It actually causes a problem, since when I add both this and libSEDML and/or libSBML to a 'x-deps' project, the 'dist' targets conflict with one another.  I think it's safest to just drop it, though it could be renamed if needed.  If it was super crucial, you could check to make sure no other 'dist' didn't already exist, and add it if so?  But I think that's overkill.