### PR TITLE
fix: corrected URN for SBML

### DIFF
--- a/examples/c++/create_sedml.cpp
+++ b/examples/c++/create_sedml.cpp
@@ -97,13 +97,13 @@ main (int argc, char* argv[])
     SedModel *model = doc.createModel();
     model->setId("model1");
     model->setSource("file.xml");
-    model->setLanguage("urn:sedml:sbml");
+    model->setLanguage("urn:sedml:language:sbml");
 
     // create a second model modifying a variable of that other sbml file
     model = doc.createModel();
     model->setId("model2");
     model->setSource("model1");
-    model->setLanguage("urn:sedml:sbml");
+    model->setLanguage("urn:sedml:language:sbml");
 
     // change a paramerter 'k' to 0.1
     SedChangeAttribute* change = model->createChangeAttribute();

--- a/examples/c/create_sedml.c
+++ b/examples/c/create_sedml.c
@@ -74,13 +74,13 @@ main (int argc, char* argv[])
   model = SedDocument_createModel(doc);
   SedModel_setId(model, "model1");
   SedModel_setSource(model, "file.xml");
-  SedModel_setLanguage(model, "urn:sedml:sbml");
+  SedModel_setLanguage(model, "urn:sedml:language:sbml");
 
   /* create a second model modifying a variable of that other sbml file */
   model = SedDocument_createModel(doc);
   SedModel_setId(model, "model2");
   SedModel_setSource(model, "model1");
-  SedModel_setLanguage(model, "urn:sedml:sbml");
+  SedModel_setLanguage(model, "urn:sedml:language:sbml");
 
   /* change a paramerter 'k' to 0.1 */
   change = SedModel_createChangeAttribute(model);

--- a/examples/csharp/create_sedml.cs
+++ b/examples/csharp/create_sedml.cs
@@ -60,13 +60,13 @@ public static int Main (string[] args)
   SedModel model = doc.createModel();
   model.setId("model1");
   model.setSource("file.xml");
-  model.setLanguage("urn:sedml:sbml");
+  model.setLanguage("urn:sedml:language:sbml");
 
   // create a second model modifying a variable of that other sbml file
   model = doc.createModel();
   model.setId("model2");
   model.setSource("model1");
-  model.setLanguage("urn:sedml:sbml");
+  model.setLanguage("urn:sedml:language:sbml");
 
   // change a paramerter 'k' to 0.1
   SedChangeAttribute change = model.createChangeAttribute();

--- a/examples/java/create_sedml.java
+++ b/examples/java/create_sedml.java
@@ -60,13 +60,13 @@ public static void main (String[] args)
   SedModel model = doc.createModel();
   model.setId("model1");
   model.setSource("file.xml");
-  model.setLanguage("urn:sedml:sbml");
+  model.setLanguage("urn:sedml:language:sbml");
 
   // create a second model modifying a variable of that other sbml file
   model = doc.createModel();
   model.setId("model2");
   model.setSource("model1");
-  model.setLanguage("urn:sedml:sbml");
+  model.setLanguage("urn:sedml:language:sbml");
 
   // change a paramerter 'k' to 0.1
   SedChangeAttribute change = model.createChangeAttribute();

--- a/examples/perl/create_sedml.pl
+++ b/examples/perl/create_sedml.pl
@@ -54,13 +54,13 @@ $doc->setVersion(1);
 $model = $doc->createModel();
 $model->setId("model1");
 $model->setSource("file.xml");
-$model->setLanguage("urn:sedml:sbml");
+$model->setLanguage("urn:sedml:language:sbml");
 
 # create a second $model modifying a variable of that other sbml file
 $model = $doc->createModel();
 $model->setId("model2");
 $model->setSource("model1");
-$model->setLanguage("urn:sedml:sbml");
+$model->setLanguage("urn:sedml:language:sbml");
 
 # change a paramerter 'k' to 0.1
 $change = $model->createChangeAttribute();

--- a/examples/python/create_dependent_variable.py
+++ b/examples/python/create_dependent_variable.py
@@ -10,7 +10,7 @@ def create_dependent_variable_example(file_name):
     model = doc.createModel()
     model.setId("model1")
     model.setSource("oscli.xml")
-    model.setLanguage("urn:sedml:sbml")
+    model.setLanguage("urn:sedml:language:sbml")
 
     # create simulation
     tc = doc.createUniformTimeCourse()

--- a/examples/python/create_pe.py
+++ b/examples/python/create_pe.py
@@ -153,7 +153,7 @@ def create_pe_example(file_name):
     model = doc.createModel()
     model.setId("model1")
     model.setSource("file.xml")
-    model.setLanguage("urn:sedml:sbml")
+    model.setLanguage("urn:sedml:language:sbml")
 
     create_data_description(doc)
 

--- a/examples/python/create_sedml.py
+++ b/examples/python/create_sedml.py
@@ -60,7 +60,7 @@ def main (args):
   model = doc.createModel()
   model.setId("model2")
   model.setSource("model1")
-  model.setLanguage("urn:sedml:sbml")
+  model.setLanguage("urn:sedml:language:sbml")
 
   # change a paramerter 'k' to 0.1
   change = model.createChangeAttribute()

--- a/examples/python/create_sedml.py
+++ b/examples/python/create_sedml.py
@@ -54,7 +54,7 @@ def main (args):
   model = doc.createModel()
   model.setId("model1")
   model.setSource("file.xml")
-  model.setLanguage("urn:sedml:sbml")
+  model.setLanguage("urn:sedml:language:sbml")
 
   # create a second model modifying a variable of that other sbml file
   model = doc.createModel()

--- a/examples/r/create_sedml.R
+++ b/examples/r/create_sedml.R
@@ -54,13 +54,13 @@ SedDocument_setVersion(doc, 1);
 model = SedDocument_createModel(doc);
 SedModel_setId(model, "model1");
 SedModel_setSource(model, "file.xml");
-SedModel_setLanguage(model, "urn:sedml:sbml");
+SedModel_setLanguage(model, "urn:sedml:language:sbml");
 
 #  create a second model modifying a variable of that other sbml file 
 model = SedDocument_createModel(doc);
 SedModel_setId(model, "model2");
 SedModel_setSource(model, "model1");
-SedModel_setLanguage(model, "urn:sedml:sbml");
+SedModel_setLanguage(model, "urn:sedml:language:sbml");
 
 #  change a paramerter 'k' to 0.1 
 change = SedModel_createChangeAttribute(model);

--- a/examples/ruby/create_sedml.rb
+++ b/examples/ruby/create_sedml.rb
@@ -49,13 +49,13 @@ doc.setVersion(1);
 model = doc.createModel();
 model.setId("model1");
 model.setSource("file.xml");
-model.setLanguage("urn:sedml:sbml");
+model.setLanguage("urn:sedml:language:sbml");
 
 # create a second model modifying a variable of that other sbml file
 model = doc.createModel();
 model.setId("model2");
 model.setSource("model1");
-model.setLanguage("urn:sedml:sbml");
+model.setLanguage("urn:sedml:language:sbml");
 
 # change a paramerter 'k' to 0.1
 change = model.createChangeAttribute();

--- a/examples/xml/l1v4/dependent_example.xml
+++ b/examples/xml/l1v4/dependent_example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <sedML xmlns="http://sed-ml.org/sed-ml/level1/version4" level="1" version="4">
   <listOfModels>
-    <model id="model1" language="urn:sedml:sbml" source="oscli.xml"/>
+    <model id="model1" language="urn:sedml:language:sbml" source="oscli.xml"/>
   </listOfModels>
   <listOfSimulations>
     <uniformTimeCourse id="sim1" initialTime="0" outputStartTime="0" outputEndTime="10" numberOfPoints="1000">

--- a/examples/xml/l1v4/pe-example.xml
+++ b/examples/xml/l1v4/pe-example.xml
@@ -20,7 +20,7 @@
     </dataDescription>
   </listOfDataDescriptions>
   <listOfModels>
-    <model id="model1" language="urn:sedml:sbml" source="file.xml"/>
+    <model id="model1" language="urn:sedml:language:sbml" source="file.xml"/>
   </listOfModels>
   <listOfTasks>
     <parameterEstimationTask id="pe1">


### PR DESCRIPTION
Corrected `urn:sedml:sbml` to `urn:sedml:language:sbml` in 3 Python files. This problem should also be corrected in 9 additional non-Python files. See https://github.com/fbergmann/libSEDML/search?q=%22urn%3Asedml%3Asbml%22.